### PR TITLE
History downloader import

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,11 +5,8 @@ class Config:
     Used to load configurations from a config.json file that contains private information and shoul never be in the repository
     '''
 
-    def __init__(self):
-        with open('config.json') as config_file:
-            self.config_data = json.load(config_file)
-
-    def get_config(self, config_name : str):
+    @staticmethod
+    def get_config(config_name : str):
         '''
         Reads config file and looks for the given key.
 
@@ -19,4 +16,5 @@ class Config:
         Returns:
             str containing the value if the key was found in the config file, None otherwise
         '''
-        return self.config_data[config_name]
+        with open('config.json') as config_file:
+            return json.load(config_file)[config_name]

--- a/download/__init__.py
+++ b/download/__init__.py
@@ -1,0 +1,1 @@
+# Empty file used for import

--- a/download/alphavantage_downloader.py
+++ b/download/alphavantage_downloader.py
@@ -1,0 +1,83 @@
+from alpha_vantage.timeseries import TimeSeries
+from download.timeseries_downloader import TimeseriesDownloader
+from datetime import date, datetime
+from pytz import timezone
+import json
+
+GMT = timezone("GMT")
+TIME_ZONE_KEY = "6. Time Zone"
+
+class AVDownloader(TimeseriesDownloader):
+    '''
+    TODO: class specifications
+    '''
+    
+    def __init__(self, api_key : str):
+        '''
+        Init method.
+        Parameters:
+            key : str
+                the Alpha Vantage API key to use
+            dir_path : Path
+                The Path object representing the destination folder, file names will be concatenated directly.
+        '''
+        self.ts = TimeSeries(api_key)
+
+    def download_between_dates(self, ticker : str, start_date : date, end_date : date, interval : str = "1m"):
+        '''
+        Downloads quote data for a single ticker given the start date and end date.
+
+        Parameters:
+            ticker : str
+                The simbol to download data of.
+            start_datetime : datetime
+                Must be before end_datetime.
+            end_datetime : datetime
+                Must be after and different from start_datetime.
+            interval : str
+                Could be "1m" (7 days max); "2m", "5m", "15m", "30m", "90m" (60 days max); "60m", "1h" (730 days max); "1d", "5d", "1wk"
+        Returns:
+            False if there has been an error,
+            a dict containing "metadata" and "atoms" otherwise.
+
+            metadata is a dict containing at least:
+                - ticker
+                - interval
+                - provider
+                - other data that the atomizer could want to apply to every atom
+            
+            atoms is a list of dicts containing:
+                - datetime (format Y-m-d H:m:s.ms)
+                - other financial values
+        '''
+
+        try:
+            data, meta = self.ts.get_intraday(ticker, interval=interval, outputsize='full')
+            new_data = dict()
+            new_data['metadata'] = { "ticker": ticker, "interval": interval, "provider": "alpha vantage"}
+            new_data['atoms'] = list()
+            tz = meta[TIME_ZONE_KEY]
+            for k, v in data.items():
+                # Datetime key and atom value
+                v['datetime'] = AVDownloader.__convert_to_gmt(date_time=datetime.strptime(k, "%Y-%m-%d %H:%M:%S"),zonename=tz).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+                new_data['atoms'].append(v)
+            
+            return new_data
+        except ValueError:
+            return False
+
+    @staticmethod
+    def __convert_to_gmt(*, date_time: datetime, zonename: str) -> datetime:
+        '''
+        Method to convert a datetime in a certain timezone to a GMT datetime
+        Parameters:
+            date_time : datetime
+                The datetime to convert
+            zonename : str
+                The time zone's name
+        Returns:
+            The datetime object in GMT time
+        '''
+        zone = timezone(zonename)
+        base = zone.localize(date_time)
+        return base.astimezone(GMT)

--- a/download/alphavantage_downloader.py
+++ b/download/alphavantage_downloader.py
@@ -1,5 +1,5 @@
 from alpha_vantage.timeseries import TimeSeries
-from download.timeseries_downloader import TimeseriesDownloader
+from download.timeseries_downloader import TimeseriesDownloader, Union
 from datetime import date, datetime
 from pytz import timezone
 import json
@@ -7,23 +7,22 @@ import json
 GMT = timezone("GMT")
 TIME_ZONE_KEY = "6. Time Zone"
 
+
 class AVDownloader(TimeseriesDownloader):
     '''
     TODO: class specifications
     '''
-    
-    def __init__(self, api_key : str):
+
+    def __init__(self, api_key: str):
         '''
         Init method.
         Parameters:
             key : str
                 the Alpha Vantage API key to use
-            dir_path : Path
-                The Path object representing the destination folder, file names will be concatenated directly.
         '''
         self.ts = TimeSeries(api_key)
 
-    def download_between_dates(self, ticker : str, start_date : date, end_date : date, interval : str = "1m"):
+    def download_between_dates(self, ticker: str, start_date: date, end_date: date, interval: str = "1m") -> Union[dict,bool]:
         '''
         Downloads quote data for a single ticker given the start date and end date.
 
@@ -45,23 +44,26 @@ class AVDownloader(TimeseriesDownloader):
                 - interval
                 - provider
                 - other data that the atomizer could want to apply to every atom
-            
+
             atoms is a list of dicts containing:
                 - datetime (format Y-m-d H:m:s.ms)
                 - other financial values
         '''
 
         try:
-            data, meta = self.ts.get_intraday(ticker, interval=interval, outputsize='full')
+            data, meta = self.ts.get_intraday(
+                ticker, interval=interval, outputsize='full')
             new_data = dict()
-            new_data['metadata'] = { "ticker": ticker, "interval": interval, "provider": "alpha vantage"}
+            new_data['metadata'] = {
+                "ticker": ticker, "interval": interval, "provider": "alpha vantage"}
             new_data['atoms'] = list()
             tz = meta[TIME_ZONE_KEY]
             for k, v in data.items():
                 # Datetime key and atom value
-                v['datetime'] = AVDownloader.__convert_to_gmt(date_time=datetime.strptime(k, "%Y-%m-%d %H:%M:%S"),zonename=tz).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+                v['datetime'] = AVDownloader.__convert_to_gmt(date_time=datetime.strptime(
+                    k, "%Y-%m-%d %H:%M:%S"), zonename=tz).strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
                 new_data['atoms'].append(v)
-            
+
             return new_data
         except ValueError:
             return False

--- a/download/alphavantage_downloader.py
+++ b/download/alphavantage_downloader.py
@@ -1,5 +1,5 @@
 from alpha_vantage.timeseries import TimeSeries
-from download.timeseries_downloader import TimeseriesDownloader, Union
+from download.timeseries_downloader import TimeseriesDownloader, Union, METADATA_KEY, META_INTERVAL_KEY, META_PROVIDER_KEY, META_TICKER_KEY, ATOMS_KEY
 from datetime import date, datetime
 from pytz import timezone
 import importer.json_key_handler as json_kh
@@ -14,6 +14,7 @@ AV_ALIASES = {
     "4. close": "close",
     "5. volume": "volume"
 }
+META_PROVIDER_VALUE = "alpha vantage"
 
 
 class AVDownloader(TimeseriesDownloader):
@@ -73,9 +74,11 @@ class AVDownloader(TimeseriesDownloader):
         atoms = AVDownloader.__filter_atoms_by_date(
             atoms=atoms, start_date=start_date, end_date=end_date)
         data = dict()
-        data['atoms'] = atoms
-        data['metadata'] = {"ticker": ticker,
-                            "interval": interval, "provider": "alpha vantage"}
+        data[ATOMS_KEY] = atoms
+        data[METADATA_KEY] = {META_TICKER_KEY: ticker,
+                            META_INTERVAL_KEY: interval,
+                            META_PROVIDER_KEY: META_PROVIDER_VALUE,
+                            "last refreshed": meta['3. Last Refreshed']}
         return data
 
     def __call_timeseries_function(self, start_date: date, interval: str, ticker: str):

--- a/download/alphavantage_downloader.py
+++ b/download/alphavantage_downloader.py
@@ -1,6 +1,6 @@
 from alpha_vantage.timeseries import TimeSeries
 from download.timeseries_downloader import TimeseriesDownloader, Union
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
 from pytz import timezone
 import importer.json_key_handler as json_kh
 import json
@@ -14,6 +14,7 @@ AV_ALIASES = {
     "4. close": "close",
     "5. volume": "volume"
 }
+
 
 class AVDownloader(TimeseriesDownloader):
     '''
@@ -66,16 +67,18 @@ class AVDownloader(TimeseriesDownloader):
             return False
         dict_data = json.loads(values.to_json(orient="table"))
         atoms = dict_data['data']
-        atoms = AVDownloader.__fix_atoms_datetime(atoms=atoms,tz=meta[TIME_ZONE_KEY])
+        atoms = AVDownloader.__fix_atoms_datetime(
+            atoms=atoms, tz=meta[TIME_ZONE_KEY])
         atoms = json_kh.rename_deep(atoms, AV_ALIASES)
-        atoms = AVDownloader.__filter_atoms_by_date(atoms=atoms, start_date=start_date, end_date=end_date)
+        atoms = AVDownloader.__filter_atoms_by_date(
+            atoms=atoms, start_date=start_date, end_date=end_date)
         data = dict()
         data['atoms'] = atoms
         data['metadata'] = {"ticker": ticker,
                             "interval": interval, "provider": "alpha vantage"}
         return data
 
-    def __call_timeseries_function(self, start_date : date, interval: str, ticker: str):
+    def __call_timeseries_function(self, start_date: date, interval: str, ticker: str):
         '''
         Calculates the right function to use for the given start date and interval.
 
@@ -99,7 +102,7 @@ class AVDownloader(TimeseriesDownloader):
         return self.ts.get_intraday(symbol=ticker, outputsize='full', interval=interval)
 
     @staticmethod
-    def __filter_atoms_by_date(*, atoms : list, start_date : date, end_date : date) -> list:
+    def __filter_atoms_by_date(*, atoms: list, start_date: date, end_date: date) -> list:
         '''
         Trims atoms from the list that don't belong to the interval [start_date, end_date].
 
@@ -114,17 +117,19 @@ class AVDownloader(TimeseriesDownloader):
             The trimmed list of atoms.
         '''
         required_atoms = list()
-        start_datetime = datetime(start_date.year, start_date.month, start_date.day)
+        start_datetime = datetime(
+            start_date.year, start_date.month, start_date.day)
         end_datetime = datetime(end_date.year, end_date.month, end_date.day)
 
         for atom in atoms:
-            atom_datetime = datetime.strptime(atom['datetime'],"%Y-%m-%d %H:%M:%S.%f")
+            atom_datetime = datetime.strptime(
+                atom['datetime'], "%Y-%m-%d %H:%M:%S.%f")
             if(atom_datetime >= start_datetime and atom_datetime <= end_datetime):
                 required_atoms.append(atom)
         return required_atoms
 
     @staticmethod
-    def __fix_atoms_datetime(*, atoms : list, tz : str) -> list:
+    def __fix_atoms_datetime(*, atoms: list, tz: str) -> list:
         '''
         Changes atoms datetime from custom timezone to UTC.
         Also changes datetime dictionary key from "date" to "datetime".

--- a/download/alphavantage_downloader.py
+++ b/download/alphavantage_downloader.py
@@ -17,7 +17,7 @@ AV_ALIASES = {
 
 class AVDownloader(TimeseriesDownloader):
     '''
-    TODO: class specifications
+     Used to download Timeseries data from AlphaVantage.
     '''
 
     def __init__(self, api_key: str):
@@ -80,10 +80,16 @@ class AVDownloader(TimeseriesDownloader):
         Calculates the right function to use for the given start date and interval.
 
         Parameters:
-            TODO
+            start_date : date
+                Required beginning of data.
+            interval : str
+                Requied data interval.
+            ticker : str
+                Required ticker.
         Returns:
-            A classfunction containing the AV function.
-            If there is no solution (eg. interval too short)
+            A pandas.Dataframe of required data if successful.
+        Raises:
+            ValueError: if it couldn't download data.
         '''
 
         if(interval == "1wk"):
@@ -94,6 +100,19 @@ class AVDownloader(TimeseriesDownloader):
 
     @staticmethod
     def __filter_atoms_by_date(*, atoms : list, start_date : date, end_date : date) -> list:
+        '''
+        Trims atoms from the list that don't belong to the interval [start_date, end_date].
+
+        Parameters:
+            atoms : list
+                List of downloaded atoms.
+            start_date : date
+                Beginning of required data.
+            end_date : date
+                End of required data.
+        Returns:
+            The trimmed list of atoms.
+        '''
         required_atoms = list()
         start_datetime = datetime(start_date.year, start_date.month, start_date.day)
         end_datetime = datetime(end_date.year, end_date.month, end_date.day)
@@ -108,12 +127,15 @@ class AVDownloader(TimeseriesDownloader):
     def __fix_atoms_datetime(*, atoms : list, tz : str) -> list:
         '''
         Changes atoms datetime from custom timezone to UTC.
-        Also changes datetime dictionary key from "date" to "datetime"
+        Also changes datetime dictionary key from "date" to "datetime".
+
         Parameters:
             atoms : list
                 List of un-treated atoms, should contain datetime in "date".
             tz : str
                 Current atoms datetime timezone.
+        Returns:
+            The list of atoms with the correct datetime.
         '''
         for atom in atoms:
             atom["datetime"] = AVDownloader.__convert_to_gmt(date_time=datetime.strptime(atom.pop("date"), "%Y-%m-%dT%H:%M:%S.%fZ"),
@@ -123,23 +145,31 @@ class AVDownloader(TimeseriesDownloader):
     @staticmethod
     def __convert_to_gmt(*, date_time: datetime, zonename: str) -> datetime:
         '''
-        Method to convert a datetime in a certain timezone to a GMT datetime
+        Method to convert a datetime in a certain timezone to a GMT datetime.
         Parameters:
             date_time : datetime
-                The datetime to convert
+                The datetime to convert.
             zonename : str
-                The time zone's name
+                The time zone's name.
         Returns:
-            The datetime object in GMT time
+            The datetime object in GMT time.
         '''
         zone = timezone(zonename)
         base = zone.localize(date_time)
         return base.astimezone(GMT)
 
     @staticmethod
-    def __standardize_interval(interval: str):
+    def __standardize_interval(interval: str) -> str:
         '''
-        Standardizes interval format frequired from alpha vantage API.
+        Standardizes interval format required from Alpha Vantage API.
+
+        Parameters:
+            interval : str
+                Required interval.
+        Returns:
+            The interval formatted for Alpha Vantage.
+        Raises:
+            ValueError: if the interval is not one from the list of possible intervals.
         '''
         if interval[-1] == "m":  # Could be 1m, convert it to 1min
             return interval + "in"

--- a/download/timeseries_downloader.py
+++ b/download/timeseries_downloader.py
@@ -1,5 +1,11 @@
 from datetime import datetime
 
+ATOMS_KEY = "atoms"
+METADATA_KEY = "metadata"
+META_TICKER_KEY = "ticker"
+META_INTERVAL_KEY = "interval"
+META_PROVIDER_KEY = "provider"
+
 class TimeseriesDownloader:
     '''
     Abstract class that defines any type of data downloading from any source of time series.

--- a/download/timeseries_downloader.py
+++ b/download/timeseries_downloader.py
@@ -5,22 +5,6 @@ class TimeseriesDownloader:
     Abstract class that defines any type of data downloading from any source of time series.
     '''
 
-    def download_period(self, ticker : str, period : str, interval : str):
-        '''
-        Downloads quote data for a single ticker given a period of time from today.
-
-        Parameters:
-            ticker : str
-                The simbol to download data of.
-            period : str
-                Period of time that could be something like "1d", "5d", "1mo", "3mo", "6mo", "1y", "2y", "5y", "10y", "ytd", "max"
-            interval : str
-                Could be "1m" (7 days max); "2m", "5m", "15m", "30m", "90m", "60m", "1h", "1d", "5d", "1wk"
-        Returns:
-            A dict of intraday data containing
-        '''
-        raise NotImplementedError("This is an abstract class, please implement this method in a child class")
-
     def download_between_dates(self, ticker : str, start : datetime, end : datetime, interval : str):
         '''
         Downloads quote data for a single ticker given two dates.
@@ -33,7 +17,7 @@ class TimeseriesDownloader:
             end_datetime : datetime
                 End datetime for data download.
             interval : str
-                Could be "1m" (7 days max); "2m", "5m", "15m", "30m", "90m", "60m", "1h", "1d", "5d", "1wk"
+                Could be "1m", "2m", "5m", "15m", "30m", "90m", "60m", "1h", "1d", "5d", "1wk"
         Returns:
             A dict containing "metadata" and "atoms".
 
@@ -47,3 +31,4 @@ class TimeseriesDownloader:
                 - datetime (format Y-m-d H:m:s.ms)
                 - other financial values
         '''
+        raise NotImplementedError("This is an abstract method, please implement it in a child class")

--- a/download/timeseries_downloader.py
+++ b/download/timeseries_downloader.py
@@ -1,0 +1,49 @@
+from datetime import datetime
+
+class TimeseriesDownloader:
+    '''
+    Abstract class that defines any type of data downloading from any source of time series.
+    '''
+
+    def download_period(self, ticker : str, period : str, interval : str):
+        '''
+        Downloads quote data for a single ticker given a period of time from today.
+
+        Parameters:
+            ticker : str
+                The simbol to download data of.
+            period : str
+                Period of time that could be something like "1d", "5d", "1mo", "3mo", "6mo", "1y", "2y", "5y", "10y", "ytd", "max"
+            interval : str
+                Could be "1m" (7 days max); "2m", "5m", "15m", "30m", "90m", "60m", "1h", "1d", "5d", "1wk"
+        Returns:
+            A dict of intraday data containing
+        '''
+        raise NotImplementedError("This is an abstract class, please implement this method in a child class")
+
+    def download_between_dates(self, ticker : str, start : datetime, end : datetime, interval : str):
+        '''
+        Downloads quote data for a single ticker given two dates.
+
+        Parameters:
+            ticker : str
+                The simbol to download data of.
+            start_datetime : datetime
+                Beginning datetime for data download.
+            end_datetime : datetime
+                End datetime for data download.
+            interval : str
+                Could be "1m" (7 days max); "2m", "5m", "15m", "30m", "90m", "60m", "1h", "1d", "5d", "1wk"
+        Returns:
+            A dict containing "metadata" and "atoms".
+
+            metadata is a dict containing at least:
+                - ticker
+                - interval
+                - provider
+                - other data that the atomizer could want to apply to every atom
+            
+            atoms is a list of dicts containing:
+                - datetime (format Y-m-d H:m:s.ms)
+                - other financial values
+        '''

--- a/download/timeseries_downloader.py
+++ b/download/timeseries_downloader.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Union
 
 ATOMS_KEY = "atoms"
 METADATA_KEY = "metadata"
@@ -6,12 +7,13 @@ META_TICKER_KEY = "ticker"
 META_INTERVAL_KEY = "interval"
 META_PROVIDER_KEY = "provider"
 
+
 class TimeseriesDownloader:
     '''
     Abstract class that defines any type of data downloading from any source of time series.
     '''
 
-    def download_between_dates(self, ticker : str, start : datetime, end : datetime, interval : str):
+    def download_between_dates(self, ticker: str, start: datetime, end: datetime, interval: str) -> Union[dict,bool]:
         '''
         Downloads quote data for a single ticker given two dates.
 
@@ -32,9 +34,10 @@ class TimeseriesDownloader:
                 - interval
                 - provider
                 - other data that the atomizer could want to apply to every atom
-            
+
             atoms is a list of dicts containing:
                 - datetime (format Y-m-d H:m:s.ms)
                 - other financial values
         '''
-        raise NotImplementedError("This is an abstract method, please implement it in a child class")
+        raise NotImplementedError(
+            "This is an abstract method, please implement it in a child class")

--- a/download/timeseries_downloader.py
+++ b/download/timeseries_downloader.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date
 from typing import Union
 
 ATOMS_KEY = "atoms"
@@ -13,17 +13,17 @@ class TimeseriesDownloader:
     Abstract class that defines any type of data downloading from any source of time series.
     '''
 
-    def download_between_dates(self, ticker: str, start: datetime, end: datetime, interval: str) -> Union[dict,bool]:
+    def download_between_dates(self, ticker: str, start: date, end: date, interval: str) -> Union[dict,bool]:
         '''
         Downloads quote data for a single ticker given two dates.
 
         Parameters:
             ticker : str
                 The simbol to download data of.
-            start_datetime : datetime
-                Beginning datetime for data download.
-            end_datetime : datetime
-                End datetime for data download.
+            start_date : date
+                Beginning date for data download.
+            end_date : date
+                End date for data download.
             interval : str
                 Could be "1m", "2m", "5m", "15m", "30m", "90m", "60m", "1h", "1d", "5d", "1wk"
         Returns:

--- a/download/yahoo_downloader.py
+++ b/download/yahoo_downloader.py
@@ -1,50 +1,14 @@
-'''
-Classes:
-YFinanceDownloader -- Download all kind of data from Yahoo Finance
-'''
-from pathlib import Path
-from datetime import date, timedelta
-from pandas import  DataFrame
+from datetime import date
+from download.timeseries_downloader import TimeseriesDownloader
 import json
 import yfinance as yf
 
-class YahooDownloader:
+class YahooDownloader(TimeseriesDownloader):
     '''
-    Attributes:
-        files_directory : pathlib.Path
-            Directory where to put JSON output files in.
     
     '''
-    def __init__(self, files_directory : Path):
-        '''
-        Parameters:
-        
-            files_directory : pathlib.Path
-                Existing system directory where to put JSON output files in.
-        '''
-        self.files_directory = files_directory
 
-    def download_period(self, ticker : str, period : str, interval : str = "1d"):
-        '''
-        Downloads quote data for a single ticker given a period of time from today.
-
-        Parameters:
-            ticker : str
-                The simbol to download data of.
-            period : str
-                Period of time that could be 1d, 5d, 1mo, 3mo, 6mo, 1y, 2y, 5y, 10y, ytd, max
-            interval : str
-                Could be "1m" (7 days max); "2m", "5m", "15m", "30m", "90m" (60 days max); "60m", "1h" (730 days max); "1d", "5d", "1wk"
-        '''
-        yf_data = yf.download(ticker, period=period, interval=interval, round=False, progress=False, prepost = True)
-
-        # If no data is downloaded it means that the ticker couldn't be found or there has been an error, we're not creating any output file then.
-        if yf_data.empty:
-            return False
-
-        return self.__write_on_JSON_file(YFinanceDownloader.__output_JSON_filename_period(ticker, period), yf_data, ticker, interval)
-
-    def download_dates(self, ticker : str, start_date : date, end_date : date, interval : str = "1d"):
+    def download_between_dates(self, ticker : str, start_date : date, end_date : date, interval : str = "1m"):
         '''
         Downloads quote data for a single ticker given the start date and end date.
 
@@ -54,124 +18,46 @@ class YahooDownloader:
             start_datetime : datetime
                 Must be before end_datetime.
             end_datetime : datetime
-                Must be after start_datetime.
+                Must be after and different from start_datetime.
             interval : str
                 Could be "1m" (7 days max); "2m", "5m", "15m", "30m", "90m" (60 days max); "60m", "1h" (730 days max); "1d", "5d", "1wk"
-        '''
+        Returns:
+            False if there has been an error,
+            a dict containing "metadata" and "atoms" otherwise.
 
-        yf_data = yf.download(ticker, start=YFinanceDownloader.__yahoo_time_format(start_date), end=YFinanceDownloader.__yahoo_time_format(end_date), interval=interval, round=False, progress=False, prepost = True)
+            metadata is a dict containing at least:
+                - ticker
+                - interval
+                - provider
+                - other data that the atomizer could want to apply to every atom
+            
+            atoms is a list of dicts containing:
+                - datetime (format Y-m-d H:m:s.ms)
+                - other financial values
+        '''
+        #yf_data is type of pandas.Dataframe
+        yf_data = yf.download(ticker, start=YahooDownloader.__yahoo_time_format(start_date), end=YahooDownloader.__yahoo_time_format(end_date), interval=interval, round=False, progress=False, prepost = True)
 
         # If no data is downloaded it means that the ticker couldn't be found or there has been an error, we're not creating any output file then.
         if yf_data.empty:
             return False
-
-        return self.__write_on_JSON_file(YFinanceDownloader.__output_JSON_filename_dates(ticker, start_date, end_date), yf_data, ticker, interval)
-
-    def download_minimum_interval(self, ticker : str, start_date : date, end_date : date):
-        '''
-        Downloads quote data for a single ticker given the start date and end date, using the smallest interval
-        available for the given dates.
-
-        Parameters:
-            ticker : str
-                The simbol to download data of.
-            start_datetime : datetime
-                Must be before end_datetime.
-            end_datetime : datetime
-                Must be after start_datetime.
-        '''
-        return self.download_dates(ticker, start_date, end_date, YFinanceDownloader.__calc_minimum_interval(start_date))
-
-
-    def download_last_week(self, ticker : str):
-        '''Downloads quote data for a single ticker a puts it in a beautified JSON file.
-
-        Parameters:
-            ticker : str
-                The symbol to download data of. Could be with market indication (FTSEMIB) or with market (FTSEMIB.MI).
-        '''
-
-        today = date.today()
-        seven_days_ago = today - timedelta(days=7)
-
-        return self.download_minimum_interval(ticker, seven_days_ago, today)
-
-    def __write_on_JSON_file(self, json_filename : str, yf_data : DataFrame, ticker_name : str, interval : str):
-        '''
-        Creates a new file in the files_directory and fills it with tabled Dataframe with the ticker's name added
-        Parameters:
-            json_filename : str
-                Filename where to put data
-            yf_data : DataFrame
-                Downloaded data with yf.download()
-            ticker_name : str
-                Ticker name to be added to the output json file
-            interval : str
-                Interval resolution data has been downloaded
-        '''
-        json_filepath = Path(self.files_directory, json_filename)
-        json_dict = json.loads(yf_data.to_json(orient="table"))
-        meta = dict()
-        meta['ticker'] = ticker_name
-        meta['interval'] = interval
-        meta['provider'] = "yahoo finance"
-        json_dict['metadata'] = meta
-        json_filepath.open("w+").write(json.dumps(json_dict, indent=4))
-        return json_filepath
+        
+        return YahooDownloader.__format_data(yf_data, ticker, interval)
 
     @staticmethod
     def __yahoo_time_format(date : date):
         '''
         Formats time into yfinance-ready string format for start date and end date.
         Parameters:
-            date : datetime.date
-                Date to be formatted for yfinance start and end times.
+            date : datetime
+                Datetime to be formatted for yfinance start and end times.
         '''
         return date.strftime("%Y-%m-%d")
 
     @staticmethod
-    def __output_JSON_filename_dates(ticker : str, start_date : date, end_date : date):
-        '''
-        Generates the JSON output file's name using ticker, data start date and end date.
-        Parameters:
-            ticker : str
-                Output ticker's name.
-            start_datetime : datetime
-                Beginning date of output data.
-            end_datetime : datetime
-                End date of output data.
-        '''
-        return "{}_{}_to_{}.json".format(ticker, start_date.strftime("%d-%m-%y"), end_date.strftime("%d-%m-%y"))
-
-    @staticmethod
-    def __output_JSON_filename_period(ticker : str, period : str):
-        '''
-        Generates the JSON output file's name using ticker and period of time.
-        Parameters:
-            ticker : str
-                Output ticker's name.
-            period : str
-                Yahoo's period of time
-        '''
-        return "{}_{}_{}.json".format(ticker, date.today().strftime("%d-%m-%y"), period)
-
-    @staticmethod
-    def __calc_minimum_interval(start_date : date):
-        '''
-        Calculates the shortest interval (from 1min to 1day) allowed for the given interval. For the calculation we only need the start datetime because
-        it depends on how old is the wanted data.
-        Parameters:
-            start_datetime: datetime
-                Beginning date of wanted data.
-        Returns: The correct shortest yfinance interval
-        '''
-        days_difference = (date.today() - start_date).days
-
-        if days_difference <= 7:
-            return "1m"
-        elif days_difference <= 60:
-            return "2m"
-        elif days_difference <= 730:
-            return "1h"
-        else:
-            return "1d"
+    def __format_data(yf_data : dict, ticker : str, interval : str):
+        json_data = json.loads(yf_data.to_json(orient="table"))
+        json_data['atoms'] = json_data.pop("data")
+        json_data['metadata'] = {"ticker": ticker, "interval": interval, "provider" : "yahoo finance"}
+        del json_data['schema']
+        return json_data

--- a/download/yahoo_downloader.py
+++ b/download/yahoo_downloader.py
@@ -12,7 +12,7 @@ class YahooDownloader(TimeseriesDownloader):
     Used to download Timeseries data from YahooFinance.
     '''
 
-    def download_between_dates(self, ticker: str, start_date: date, end_date: date, interval: str = "1m") -> Union[dict,bool]:
+    def download_between_dates(self, ticker: str, start_date: date, end_date: date, interval: str = "1m") -> Union[dict, bool]:
         '''
         Downloads quote data for a single ticker given the start date and end date.
 

--- a/download/yahoo_downloader.py
+++ b/download/yahoo_downloader.py
@@ -9,7 +9,7 @@ META_PROVIDER_VALUE = "yahoo finance"
 
 class YahooDownloader(TimeseriesDownloader):
     '''
-    TODO: class specifications
+    Used to download Timeseries data from YahooFinance.
     '''
 
     def download_between_dates(self, ticker: str, start_date: date, end_date: date, interval: str = "1m") -> Union[dict,bool]:

--- a/download/yahoo_downloader.py
+++ b/download/yahoo_downloader.py
@@ -1,0 +1,177 @@
+'''
+Classes:
+YFinanceDownloader -- Download all kind of data from Yahoo Finance
+'''
+from pathlib import Path
+from datetime import date, timedelta
+from pandas import  DataFrame
+import json
+import yfinance as yf
+
+class YahooDownloader:
+    '''
+    Attributes:
+        files_directory : pathlib.Path
+            Directory where to put JSON output files in.
+    
+    '''
+    def __init__(self, files_directory : Path):
+        '''
+        Parameters:
+        
+            files_directory : pathlib.Path
+                Existing system directory where to put JSON output files in.
+        '''
+        self.files_directory = files_directory
+
+    def download_period(self, ticker : str, period : str, interval : str = "1d"):
+        '''
+        Downloads quote data for a single ticker given a period of time from today.
+
+        Parameters:
+            ticker : str
+                The simbol to download data of.
+            period : str
+                Period of time that could be 1d, 5d, 1mo, 3mo, 6mo, 1y, 2y, 5y, 10y, ytd, max
+            interval : str
+                Could be "1m" (7 days max); "2m", "5m", "15m", "30m", "90m" (60 days max); "60m", "1h" (730 days max); "1d", "5d", "1wk"
+        '''
+        yf_data = yf.download(ticker, period=period, interval=interval, round=False, progress=False, prepost = True)
+
+        # If no data is downloaded it means that the ticker couldn't be found or there has been an error, we're not creating any output file then.
+        if yf_data.empty:
+            return False
+
+        return self.__write_on_JSON_file(YFinanceDownloader.__output_JSON_filename_period(ticker, period), yf_data, ticker, interval)
+
+    def download_dates(self, ticker : str, start_date : date, end_date : date, interval : str = "1d"):
+        '''
+        Downloads quote data for a single ticker given the start date and end date.
+
+        Parameters:
+            ticker : str
+                The simbol to download data of.
+            start_datetime : datetime
+                Must be before end_datetime.
+            end_datetime : datetime
+                Must be after start_datetime.
+            interval : str
+                Could be "1m" (7 days max); "2m", "5m", "15m", "30m", "90m" (60 days max); "60m", "1h" (730 days max); "1d", "5d", "1wk"
+        '''
+
+        yf_data = yf.download(ticker, start=YFinanceDownloader.__yahoo_time_format(start_date), end=YFinanceDownloader.__yahoo_time_format(end_date), interval=interval, round=False, progress=False, prepost = True)
+
+        # If no data is downloaded it means that the ticker couldn't be found or there has been an error, we're not creating any output file then.
+        if yf_data.empty:
+            return False
+
+        return self.__write_on_JSON_file(YFinanceDownloader.__output_JSON_filename_dates(ticker, start_date, end_date), yf_data, ticker, interval)
+
+    def download_minimum_interval(self, ticker : str, start_date : date, end_date : date):
+        '''
+        Downloads quote data for a single ticker given the start date and end date, using the smallest interval
+        available for the given dates.
+
+        Parameters:
+            ticker : str
+                The simbol to download data of.
+            start_datetime : datetime
+                Must be before end_datetime.
+            end_datetime : datetime
+                Must be after start_datetime.
+        '''
+        return self.download_dates(ticker, start_date, end_date, YFinanceDownloader.__calc_minimum_interval(start_date))
+
+
+    def download_last_week(self, ticker : str):
+        '''Downloads quote data for a single ticker a puts it in a beautified JSON file.
+
+        Parameters:
+            ticker : str
+                The symbol to download data of. Could be with market indication (FTSEMIB) or with market (FTSEMIB.MI).
+        '''
+
+        today = date.today()
+        seven_days_ago = today - timedelta(days=7)
+
+        return self.download_minimum_interval(ticker, seven_days_ago, today)
+
+    def __write_on_JSON_file(self, json_filename : str, yf_data : DataFrame, ticker_name : str, interval : str):
+        '''
+        Creates a new file in the files_directory and fills it with tabled Dataframe with the ticker's name added
+        Parameters:
+            json_filename : str
+                Filename where to put data
+            yf_data : DataFrame
+                Downloaded data with yf.download()
+            ticker_name : str
+                Ticker name to be added to the output json file
+            interval : str
+                Interval resolution data has been downloaded
+        '''
+        json_filepath = Path(self.files_directory, json_filename)
+        json_dict = json.loads(yf_data.to_json(orient="table"))
+        meta = dict()
+        meta['ticker'] = ticker_name
+        meta['interval'] = interval
+        meta['provider'] = "yahoo finance"
+        json_dict['metadata'] = meta
+        json_filepath.open("w+").write(json.dumps(json_dict, indent=4))
+        return json_filepath
+
+    @staticmethod
+    def __yahoo_time_format(date : date):
+        '''
+        Formats time into yfinance-ready string format for start date and end date.
+        Parameters:
+            date : datetime.date
+                Date to be formatted for yfinance start and end times.
+        '''
+        return date.strftime("%Y-%m-%d")
+
+    @staticmethod
+    def __output_JSON_filename_dates(ticker : str, start_date : date, end_date : date):
+        '''
+        Generates the JSON output file's name using ticker, data start date and end date.
+        Parameters:
+            ticker : str
+                Output ticker's name.
+            start_datetime : datetime
+                Beginning date of output data.
+            end_datetime : datetime
+                End date of output data.
+        '''
+        return "{}_{}_to_{}.json".format(ticker, start_date.strftime("%d-%m-%y"), end_date.strftime("%d-%m-%y"))
+
+    @staticmethod
+    def __output_JSON_filename_period(ticker : str, period : str):
+        '''
+        Generates the JSON output file's name using ticker and period of time.
+        Parameters:
+            ticker : str
+                Output ticker's name.
+            period : str
+                Yahoo's period of time
+        '''
+        return "{}_{}_{}.json".format(ticker, date.today().strftime("%d-%m-%y"), period)
+
+    @staticmethod
+    def __calc_minimum_interval(start_date : date):
+        '''
+        Calculates the shortest interval (from 1min to 1day) allowed for the given interval. For the calculation we only need the start datetime because
+        it depends on how old is the wanted data.
+        Parameters:
+            start_datetime: datetime
+                Beginning date of wanted data.
+        Returns: The correct shortest yfinance interval
+        '''
+        days_difference = (date.today() - start_date).days
+
+        if days_difference <= 7:
+            return "1m"
+        elif days_difference <= 60:
+            return "2m"
+        elif days_difference <= 730:
+            return "1h"
+        else:
+            return "1d"

--- a/main.py
+++ b/main.py
@@ -59,8 +59,7 @@ def choose_path(sub_dir : Path):
     return Path(sub_dir,folder_name)
 
 if __name__ == '__main__':
-    config = Config()
-    database_adapter = PosgreSQLAdapter(config.get_config("postgre_username"), config.get_config("postgre_password"), config.get_config("postgre_host"))
+    database_adapter = PosgreSQLAdapter(Config.get_config("postgre_username"), Config.get_config("postgre_password"), Config.get_config("postgre_host"))
     
     provider = choose_provider()
     if provider :

--- a/test.py
+++ b/test.py
@@ -1,6 +1,7 @@
-from download.yahoo_downloader import YahooDownloader
+from download.alphavantage_downloader import AVDownloader
 from datetime import date
+from config import Config
 
 if __name__ == "__main__":
-    dw = YahooDownloader()
-    print(dw.download_between_dates("AAPL",date(2020,4,22),date(2020,4,23)))
+    dw = AVDownloader(Config.get_config("alphavantage_api_key"))
+    print(dw.download_between_dates("A",date(2020,4,21),date(2020,4,23)))

--- a/test.py
+++ b/test.py
@@ -10,10 +10,14 @@ if __name__ == "__main__":
     print("Ticker: ", ticker)
 
     dw = AVDownloader(Config.get_config("alphavantage_api_key"))
-    data = dw.download_between_dates(ticker,date(2020,4,19),date(2020,4,25), interval="1m")
-    print("AV min: {} max: {} len: {}".format(data['atoms'][len(data['atoms'])-1]['datetime'],data['atoms'][0]['datetime'],len(data['atoms'])))
+    data = dw.download_between_dates(ticker, date(
+        2020, 4, 19), date(2020, 4, 25), interval="1m")
+    print("AV min: {} max: {} len: {}".format(data['atoms'][len(
+        data['atoms'])-1]['datetime'], data['atoms'][0]['datetime'], len(data['atoms'])))
 
     dw2 = YahooDownloader()
-    data2 = dw2.download_between_dates(ticker=ticker,start_date=date(2020,4,19),end_date=date(2020,4,25), interval="1m")
-    print("YF min: {} max: {} len: {}".format(data2['atoms'][0]['datetime'],data2['atoms'][len(data2['atoms'])-1]['datetime'],len(data2['atoms'])))
+    data2 = dw2.download_between_dates(ticker=ticker, start_date=date(
+        2020, 4, 19), end_date=date(2020, 4, 25), interval="1m")
+    print("YF min: {} max: {} len: {}".format(data2['atoms'][0]['datetime'], data2['atoms'][len(
+        data2['atoms'])-1]['datetime'], len(data2['atoms'])))
     print(data2['atoms'])

--- a/test.py
+++ b/test.py
@@ -1,0 +1,6 @@
+from download.yahoo_downloader import YahooDownloader
+from datetime import date
+
+if __name__ == "__main__":
+    dw = YahooDownloader()
+    print(dw.download_between_dates("AAPL",date(2020,4,22),date(2020,4,23)))

--- a/test.py
+++ b/test.py
@@ -1,7 +1,19 @@
 from download.alphavantage_downloader import AVDownloader
+from download.yahoo_downloader import YahooDownloader
 from datetime import date
 from config import Config
 
 if __name__ == "__main__":
+
+    ticker = "GOOG"
+
+    print("Ticker: ", ticker)
+
     dw = AVDownloader(Config.get_config("alphavantage_api_key"))
-    print(dw.download_between_dates("A",date(2020,4,21),date(2020,4,23)))
+    data = dw.download_between_dates(ticker,date(2020,4,19),date(2020,4,25), interval="1m")
+    print("AV min: {} max: {} len: {}".format(data['atoms'][len(data['atoms'])-1]['datetime'],data['atoms'][0]['datetime'],len(data['atoms'])))
+
+    dw2 = YahooDownloader()
+    data2 = dw2.download_between_dates(ticker=ticker,start_date=date(2020,4,19),end_date=date(2020,4,25), interval="1m")
+    print("YF min: {} max: {} len: {}".format(data2['atoms'][0]['datetime'],data2['atoms'][len(data2['atoms'])-1]['datetime'],len(data2['atoms'])))
+    print(data2['atoms'])

--- a/test.py
+++ b/test.py
@@ -20,4 +20,3 @@ if __name__ == "__main__":
         2020, 4, 19), end_date=date(2020, 4, 25), interval="1m")
     print("YF min: {} max: {} len: {}".format(data2['atoms'][0]['datetime'], data2['atoms'][len(
         data2['atoms'])-1]['datetime'], len(data2['atoms'])))
-    print(data2['atoms'])


### PR DESCRIPTION
## Premise
Probably should have done this from the very beginning.

## Changes
+ added `download` directory.
+ added `yahoo_downloader`, the old yf_downloader from history-importer.
+ added `alphavantage_downloader` the old av_downloader but improved a bit.

As discussed [here](https://trello.com/c/lGkfXvg4) the two classes act as the adapter and perform the two functions of downloading and formatting/standardizing the data.

~ `config.get_config()` is now static and doesn't need class initialization.

I'll complete the TODO specifications as you read the code now.