### PR TITLE
N-Uplicator Filter

### DIFF
--- a/otri/filtering/filter.py
+++ b/otri/filtering/filter.py
@@ -51,7 +51,7 @@ class Filter:
         '''
         return self.input_streams
 
-    def get_input_stream(self, index) -> Stream:
+    def get_input_stream(self, index: int) -> Stream:
         '''
         Retrieve a sepecific input stream.
         '''
@@ -73,7 +73,7 @@ class Filter:
             raise NotImplementedError(
                 "The filter has not defined its output list with set_output_streams")
 
-    def is_finished(self)-> bool:
+    def is_finished(self) -> bool:
         '''
         Checks whether all of the output streams are flagged as finished, meaning that no more atoms will be added.
         '''

--- a/otri/filtering/filters/nuplicator_filter.py
+++ b/otri/filtering/filters/nuplicator_filter.py
@@ -9,7 +9,7 @@ class NUplicatorFilter(Filter):
     Outputs: Any number of streams.
     '''
 
-    def __init__(self, source_stream: Stream, output_streams_count: int, deep_copy: bool = False):
+    def __init__(self, source_stream: Stream, output_streams_count: int, deep_copy: bool = True):
         '''
         Parameters:
             source_stream : Stream

--- a/otri/filtering/filters/nuplicator_filter.py
+++ b/otri/filtering/filters/nuplicator_filter.py
@@ -1,0 +1,45 @@
+from ..filter import Filter, Stream, Collection
+import copy
+
+
+class NUplicatorFilter(Filter):
+    '''
+    N-uplicates the input stream. Placing a copy of the input in each output filter.
+    Inputs: a single Stream.
+    Outputs: Any number of streams.
+    '''
+
+    def __init__(self, source_stream: Stream, output_streams_count: int, deep_copy: bool = False):
+        '''
+        Parameters:
+            source_stream : Stream
+                A single Stream that must be n-uplicated
+            output_streams_count : int
+                The number of output streams for this filter
+            deep_copy : bool = False
+                Whether the items from the input stream should be deep copies or shallow copies
+        '''
+        super().__init__(
+            input_streams=[source_stream],
+            input_streams_count=1,
+            output_streams_count=output_streams_count
+        )
+        self.copy = copy.deepcopy if deep_copy else copy.copy
+        self.source_iter = source_stream.__iter__()
+
+    def execute(self):
+        '''
+        Method called when a single step in the filtering must be taken.
+        If the input stream has another item, copy it to all output streams.
+        If the input stream has no other item and got closed, then we also close
+        the output streams.
+        '''
+        if self.source_iter.has_next():
+            item = self.source_iter.__next__()
+            for output in self.get_output_streams():
+                output.append(self.copy(item))
+        elif self.get_input_stream(0).is_closed():
+            # Closed input -> Close outputs
+            for output in self.get_output_streams():
+                output.close()
+            return

--- a/test/filtering/filters/nuplicator_filter_test.py
+++ b/test/filtering/filters/nuplicator_filter_test.py
@@ -30,7 +30,7 @@ class NUplicatorFilterTest(unittest.TestCase):
     def test_simple_stream_shallow(self):
         source_stream = Stream([[["Moshi Moshi"], ["Kawaii Desu"]]])
         expected = source_stream[0]
-        nuplicator = NUplicatorFilter(source_stream, 5)
+        nuplicator = NUplicatorFilter(source_stream, 5, deep_copy=False)
         nuplicator.execute()
         # Changing the inner list, change should be reflected cause copy should be shallow
         expected[0].append("Hello")

--- a/test/filtering/filters/nuplicator_filter_test.py
+++ b/test/filtering/filters/nuplicator_filter_test.py
@@ -1,0 +1,4 @@
+import unittest
+
+class NUplicatorFilterTest(unittest.TestCase):
+    pass

--- a/test/filtering/filters/nuplicator_filter_test.py
+++ b/test/filtering/filters/nuplicator_filter_test.py
@@ -1,4 +1,48 @@
 import unittest
+from otri.filtering.filters.nuplicator_filter import NUplicatorFilter
+from otri.filtering.stream import Stream
+
 
 class NUplicatorFilterTest(unittest.TestCase):
-    pass
+
+    def test_single_input_stream(self):
+        # Testing the input stream is exactly the one we gave
+        source_stream = Stream()
+        nuplicator = NUplicatorFilter(source_stream, 1)
+        self.assertEqual(len(nuplicator.get_input_streams()), 1)
+        self.assertEqual(nuplicator.get_input_streams()[0], source_stream)
+
+    def test_exactly_n_outputs(self):
+        # Testing we get exactly n outputs
+        source_stream = Stream()
+        expected = 10
+        nuplicator = NUplicatorFilter(source_stream, expected)
+        self.assertEqual(len(nuplicator.get_output_streams()), expected)
+
+    def test_simple_stream_copying(self):
+        source_stream = Stream(range(100))
+        expected = source_stream[0]
+        nuplicator = NUplicatorFilter(source_stream, 5)
+        nuplicator.execute()
+        for output in nuplicator.get_output_streams():
+            self.assertFalse(output[0] != expected)
+
+    def test_simple_stream_shallow(self):
+        source_stream = Stream([[["Moshi Moshi"], ["Kawaii Desu"]]])
+        expected = source_stream[0]
+        nuplicator = NUplicatorFilter(source_stream, 5)
+        nuplicator.execute()
+        # Changing the inner list, change should be reflected cause copy should be shallow
+        expected[0].append("Hello")
+        for output in nuplicator.get_output_streams():
+            self.assertEqual(output[0], expected)
+
+    def test_simple_stream_deep(self):
+        source_stream = Stream([[["Moshi Moshi"], ["Kawaii Desu"]]])
+        expected = source_stream[0]
+        nuplicator = NUplicatorFilter(source_stream, 5, deep_copy=True)
+        nuplicator.execute()
+        # Changing the inner list, change should not be reflected cause copy should be deep
+        expected[0].append("Hello")
+        for output in nuplicator.get_output_streams():
+            self.assertNotEqual(output[0], expected)


### PR DESCRIPTION
## Premise
Added N-Uplicator filter. Copies the input Stream into all of his output streams.

## Features
**feat(nuplicator_filter.py):**
**+** NUplicatorFilter class, Filter that copies the input Stream to N output Streams.
Copies are shallow by default, deep copying can be requested as constructor parameter.
**test(nuplicator_filter_test.py)**
**+** Tests for the n-uplicator filter.

## Picture of a cute animal
Soz but I don't wanna waste all the cute animals I know, consider this a part two of the other filter's PR.