### PR TITLE
Integration filter

### DIFF
--- a/otri/filtering/filters/average_filter.py
+++ b/otri/filtering/filters/average_filter.py
@@ -1,14 +1,16 @@
 from ..filter import Filter, Stream, Collection
+from .integrator_filter import IntegratorFilter
 from typing import Sequence, Mapping, Dict
 from numbers import Number
 
 
-class AverageFilter(Filter):
+class AverageFilter(IntegratorFilter):
     '''
     Input: One Stream
     Output: One Stream
     Computes the average and the sum of the atoms that pass through.
     '''
+
     def __init__(self, input_stream: Stream, keys: Sequence):
         '''
         Parameters:
@@ -18,59 +20,17 @@ class AverageFilter(Filter):
                 The keys to compute the average of. Values corresponding to these keys
                 should be numbers.
         '''
-        super().__init__([input_stream],
-                         input_streams_count=1, output_streams_count=1)
-        self.__cnt = {k: 0 for k in keys}
-        self.__sum = {k: 0 for k in keys}
-        self.__avg = {k: 0 for k in keys}
-        self.__input_iter = input_stream.__iter__()
-
-    def execute(self):
-        '''
-        Pops a single atom, reads the fields in the `keys` init parameter, updates the state
-        and outputs the atom, unmodified.
-        '''
-        if self.get_output_stream(0).is_closed():
-            return
-        input_iter = self.__input_iter
-        if input_iter.has_next():
-            item = input_iter.__next__()
-            self.__update_state(item)
-            self.get_output_stream(0).append(item)
-        # Check that we didn't just pop the last item
-        if not input_iter.has_next() and self.get_input_stream(0).is_closed():
-            self.get_output_stream(0).close()
+        super().__init__(input_stream, keys)
+        self.__keys = keys
 
     def get_avgs(self) -> Dict:
         '''
         Returns:
             A copy of the dict containing all the averages, for each key.
         '''
-        return self.__avg.copy()
-
-    def get_sums(self) -> Dict:
-        '''
-        Returns:
-            A copy of the dict containing all the sums, for each key.
-        '''
-        return self.__sum.copy()
-
-    def get_counts(self) -> Dict:
-        '''
-        Returns:
-            A copy of the dict containing all the counts, for each key. Meaning how many atoms had that key.
-        '''
-        return self.__cnt.copy()
-
-    def __update_state(self, item: Mapping):
-        '''
-        Parameters:
-            item : Mapping
-                The atom to use when updating the state.
-                It is not necessary for it to have the keys.
-        '''
-        for k in self.__cnt.keys():
-            if k in item.keys() and isinstance(item[k], Number):
-                self.__cnt[k] += 1
-                self.__sum[k] += item[k]
-                self.__avg[k] = self.__sum[k] / self.__cnt[k]
+        avg_dict = dict()
+        sums = self.get_sums()
+        counts = self.get_counts()
+        for k in self.__keys:
+            avg_dict[k] = sums[k] / counts[k]
+        return avg_dict

--- a/otri/filtering/filters/integrator_filter.py
+++ b/otri/filtering/filters/integrator_filter.py
@@ -1,0 +1,67 @@
+from ..filter import Filter, Stream, Collection
+from typing import Sequence, Mapping, Dict
+from numbers import Number
+
+
+class IntegratorFilter(Filter):
+    '''
+    Input: One Stream
+    Output: One Stream
+    Computes the sum of the atoms that pass through.
+    '''
+    def __init__(self, input_stream: Stream, keys: Sequence):
+        '''
+        Parameters:
+            input_stream : Stream
+                A single Stream of atoms, which we assume to be mappings of some sort.
+            keys : Sequence
+                The keys to compute the sum of. Values corresponding to these keys
+                should be numbers.
+        '''
+        super().__init__([input_stream],
+                         input_streams_count=1, output_streams_count=1)
+        self.__cnt = {k: 0 for k in keys}
+        self.__sum = {k: 0 for k in keys}
+        self.__input_iter = input_stream.__iter__()
+
+    def execute(self):
+        '''
+        Pops a single atom, reads the fields in the `keys` init parameter, updates the state
+        and outputs the atom, unmodified.
+        '''
+        if self.get_output_stream(0).is_closed():
+            return
+        input_iter = self.__input_iter
+        if input_iter.has_next():
+            item = input_iter.__next__()
+            self.__update_state(item)
+            self.get_output_stream(0).append(item)
+        # Check that we didn't just pop the last item
+        if not input_iter.has_next() and self.get_input_stream(0).is_closed():
+            self.get_output_stream(0).close()
+
+    def get_sums(self) -> Dict:
+        '''
+        Returns:
+            A copy of the dict containing all the sums, for each key.
+        '''
+        return self.__sum.copy()
+
+    def get_counts(self) -> Dict:
+        '''
+        Returns:
+            A copy of the dict containing all the counts, for each key. Meaning how many atoms had that key.
+        '''
+        return self.__cnt.copy()
+
+    def __update_state(self, item: Mapping):
+        '''
+        Parameters:
+            item : Mapping
+                The atom to use when updating the state.
+                It is not necessary for it to have the keys.
+        '''
+        for k in self.__cnt.keys():
+            if k in item.keys() and isinstance(item[k], Number):
+                self.__cnt[k] += 1
+                self.__sum[k] += item[k]

--- a/test/filtering/filters/integrator_filter_test.py
+++ b/test/filtering/filters/integrator_filter_test.py
@@ -1,0 +1,38 @@
+from otri.filtering.filters.integrator_filter import IntegratorFilter
+from otri.filtering.stream import Stream
+import unittest
+
+
+class IntegratorFilterTest(unittest.TestCase):
+
+    def test_one_input(self):
+        avg_filter = IntegratorFilter(Stream(), {})
+        self.assertEqual(len(avg_filter.get_input_streams()), 1)
+
+    def test_one_output(self):
+        avg_filter = IntegratorFilter(Stream(), {})
+        self.assertEqual(len(avg_filter.get_output_streams()), 1)
+
+    def test_simple_stream_count(self):
+        # Checking the counting works
+        example_stream = Stream(
+            [{"a": 1}, {"a": 2}, {"a": 3}, {"a": 4}, {"a": 5}, {"b": 6}, {"c": 7}]
+        )
+        example_stream.close()
+        expected = 5
+        avg_filter = IntegratorFilter(example_stream, ("a"))
+        while len(example_stream):
+            avg_filter.execute()
+        self.assertEqual(avg_filter.get_counts()["a"], expected)
+
+    def test_simple_stream_sum(self):
+        # Checking the sum works
+        example_stream = Stream(
+            [{"a": 1}, {"a": 2}, {"a": 3}, {"a": 4}, {"a": 5}, {"b": 6}, {"c": 7}]
+        )
+        example_stream.close()
+        expected = 15
+        avg_filter = IntegratorFilter(example_stream, ("a"))
+        while len(example_stream):
+            avg_filter.execute()
+        self.assertEqual(avg_filter.get_sums()["a"], expected)


### PR DESCRIPTION
## Premise
I just copied and pasted `AverageFilter` and removed the calc of avg

## Features

#### `feat(IntegratorFilter)`
- Removed avg method from the avg filter

#### `feat(AverageFilter)`
~ Average is now calculated only when the `get_avg()` method is called.

## Picture of a cute animal
![Cute](https://media3.giphy.com/media/BLCHvwl9C5j1u/giphy.gif?cid=ecf05e470abad5bc022841ee93c94af3cdf37db3a62f8b8e&rid=giphy.gif)