### PR TITLE
style guide fix

### DIFF
--- a/STYLE-GUIDE.md
+++ b/STYLE-GUIDE.md
@@ -93,9 +93,9 @@ def method_name(self, a : str, d : dict) -> str:
 
     Parameters:
         a : str
-            Parameter description
+            Parameter description\n
         d : dict
-            Parameter description
+            Parameter description\n
 ```
 
 When possible try using `python.typing` types such as `Sequence`, `Collection`, `Mapping` instead of `dict` or `list`.
@@ -110,7 +110,7 @@ def method_name(self, filename : str, d : dict):
 
     Raises:
         FileNotFoundException
-            Thrown when the given filename is not found.
+            Thrown when the given filename is not found.\n
     '''
 ```
 


### PR DESCRIPTION
Based on how the docs are generated, a line finish should be added in between parameters or exceptions, anywhere a line finish is required, to avoid concatenation of elements on the same line.

Example:
![Cattura](https://user-images.githubusercontent.com/56487105/86794310-a6766780-c06c-11ea-9873-258bc5cee420.PNG)

## Features
Minor edits to `STYLE-GUIDE.md`