### PR TITLE
Interpolation filter refactor

### DIFF
--- a/autocorrelation.py
+++ b/autocorrelation.py
@@ -8,7 +8,7 @@ __all__ = ['autocorrelation']
 
 from otri.filtering.filter_net import FilterNet, FilterLayer, EXEC_AND_PASS, BACK_IF_NO_OUTPUT
 from otri.filtering.stream import Stream
-from otri.filtering.filters.interpolation_filter import InterpolationFilter
+from otri.filtering.filters.interpolation_filter import IntradayInterpolationFilter
 from otri.filtering.filters.phase_filter import PhaseMulFilter, PhaseDeltaFilter
 from otri.filtering.filters.statistics_filter import StatisticsFilter
 from otri.filtering.filters.generic_filter import GenericFilter
@@ -65,11 +65,11 @@ def autocorrelation(input_stream: Stream, atom_keys: Collection, distance: int =
         ], EXEC_AND_PASS),
         FilterLayer([
             # Interpolation
-            InterpolationFilter(
+            IntradayInterpolationFilter(
                 inputs="db_atoms",
                 outputs="interp_atoms",
                 keys_to_interp=atom_keys,
-                target_interval="minutes"
+                target_gap_seconds=60
             )
         ], BACK_IF_NO_OUTPUT),
         FilterLayer([

--- a/doc/otri/database/database_adapter.html
+++ b/doc/otri/database/database_adapter.html
@@ -29,6 +29,7 @@
 <pre><code class="python">from .database_query import DatabaseQuery
 from .database_data import DatabaseData
 
+
 &#39;&#39;&#39;
 Classes:
 DatabaseAdapter -- Abstract class

--- a/doc/otri/database/postgresql_adapter.html
+++ b/doc/otri/database/postgresql_adapter.html
@@ -28,6 +28,7 @@
 </summary>
 <pre><code class="python">from .database_adapter import DatabaseAdapter, DatabaseData, DatabaseQuery
 from .database_stream import PostgreSQLStream
+from ..utils import logger as log
 
 import json
 import psycopg2
@@ -52,14 +53,14 @@ class PostgreSQLAdapter(DatabaseAdapter):
                 Port where the DB is hosted
         &#39;&#39;&#39;
         try:
-            print(&#34;Trying to connect to PGSQL Database&#34;)
+            log.i(&#34;Trying to connect to PGSQL Database&#34;)
             self.connection = psycopg2.connect(
                 user=username, password=password, host=host, port=port)
             self.cursor = self.connection.cursor()
-            print(&#34;Connected to PGSQL&#34;)
+            log.i(&#34;Connected to PGSQL&#34;)
 
         except (Exception, psycopg2.Error) as error:
-            print(&#34;Error while connecting to PostgreSQL&#34;, error)
+            log.e(&#34;Error while connecting to PostgreSQL: {}&#34;.format(error))
 
     def write(self, data: DatabaseData):
         &#39;&#39;&#39;
@@ -81,12 +82,12 @@ class PostgreSQLAdapter(DatabaseAdapter):
             execute_values(self.cursor, &#34;INSERT INTO {} (data_json) VALUES %s&#34;.format(
                 data.category), data_json_list)
             self.connection.commit()
-            print(&#34;Upload completed&#34;)
+            log.v(&#34;Upload completed&#34;)
         elif(type(data.values) == dict):
             self.cursor.execute(&#34;INSERT INTO {} (data_json) VALUES %s&#34;.format(
                 data.category), (data.values,))
             self.connection.commit()
-            print(&#34;Upload completed&#34;)
+            log.v(&#34;Upload completed&#34;)
         else:
             raise ValueError(&#34;Data value not a list or a dict&#34;)
 
@@ -128,7 +129,7 @@ class PostgreSQLAdapter(DatabaseAdapter):
             table_name : str
                 Name of the table to create.
         &#39;&#39;&#39;
-        print(&#34;Creating pgSQL DB {}&#34;.format(table_name))
+        log.i(&#34;creating new pgSQL DB table {}&#34;.format(table_name))
         self.cursor.execute(
             &#34;CREATE TABLE {} (id BIGSERIAL PRIMARY KEY, data_json JSON NOT NULL);&#34;.format(table_name))
         self.connection.commit()
@@ -152,6 +153,7 @@ class PostgreSQLAdapter(DatabaseAdapter):
         Closes database connection.
         &#39;&#39;&#39;
         if(self.connection):
+            log.v(&#34;closing pgSQL DB connection&#34;)
             self.cursor.close()
             self.connection.close()</code></pre>
 </details>
@@ -201,14 +203,14 @@ Port where the DB is hosted</p></div>
                 Port where the DB is hosted
         &#39;&#39;&#39;
         try:
-            print(&#34;Trying to connect to PGSQL Database&#34;)
+            log.i(&#34;Trying to connect to PGSQL Database&#34;)
             self.connection = psycopg2.connect(
                 user=username, password=password, host=host, port=port)
             self.cursor = self.connection.cursor()
-            print(&#34;Connected to PGSQL&#34;)
+            log.i(&#34;Connected to PGSQL&#34;)
 
         except (Exception, psycopg2.Error) as error:
-            print(&#34;Error while connecting to PostgreSQL&#34;, error)
+            log.e(&#34;Error while connecting to PostgreSQL: {}&#34;.format(error))
 
     def write(self, data: DatabaseData):
         &#39;&#39;&#39;
@@ -230,12 +232,12 @@ Port where the DB is hosted</p></div>
             execute_values(self.cursor, &#34;INSERT INTO {} (data_json) VALUES %s&#34;.format(
                 data.category), data_json_list)
             self.connection.commit()
-            print(&#34;Upload completed&#34;)
+            log.v(&#34;Upload completed&#34;)
         elif(type(data.values) == dict):
             self.cursor.execute(&#34;INSERT INTO {} (data_json) VALUES %s&#34;.format(
                 data.category), (data.values,))
             self.connection.commit()
-            print(&#34;Upload completed&#34;)
+            log.v(&#34;Upload completed&#34;)
         else:
             raise ValueError(&#34;Data value not a list or a dict&#34;)
 
@@ -277,7 +279,7 @@ Port where the DB is hosted</p></div>
             table_name : str
                 Name of the table to create.
         &#39;&#39;&#39;
-        print(&#34;Creating pgSQL DB {}&#34;.format(table_name))
+        log.i(&#34;creating new pgSQL DB table {}&#34;.format(table_name))
         self.cursor.execute(
             &#34;CREATE TABLE {} (id BIGSERIAL PRIMARY KEY, data_json JSON NOT NULL);&#34;.format(table_name))
         self.connection.commit()
@@ -301,6 +303,7 @@ Port where the DB is hosted</p></div>
         Closes database connection.
         &#39;&#39;&#39;
         if(self.connection):
+            log.v(&#34;closing pgSQL DB connection&#34;)
             self.cursor.close()
             self.connection.close()</code></pre>
 </details>
@@ -324,6 +327,7 @@ Port where the DB is hosted</p></div>
     Closes database connection.
     &#39;&#39;&#39;
     if(self.connection):
+        log.v(&#34;closing pgSQL DB connection&#34;)
         self.cursor.close()
         self.connection.close()</code></pre>
 </details>
@@ -427,12 +431,12 @@ If data.values is not a list or a dict</p></div>
         execute_values(self.cursor, &#34;INSERT INTO {} (data_json) VALUES %s&#34;.format(
             data.category), data_json_list)
         self.connection.commit()
-        print(&#34;Upload completed&#34;)
+        log.v(&#34;Upload completed&#34;)
     elif(type(data.values) == dict):
         self.cursor.execute(&#34;INSERT INTO {} (data_json) VALUES %s&#34;.format(
             data.category), (data.values,))
         self.connection.commit()
-        print(&#34;Upload completed&#34;)
+        log.v(&#34;Upload completed&#34;)
     else:
         raise ValueError(&#34;Data value not a list or a dict&#34;)</code></pre>
 </details>

--- a/doc/otri/downloader/alphavantage_downloader.html
+++ b/doc/otri/downloader/alphavantage_downloader.html
@@ -31,6 +31,7 @@ from .timeseries_downloader import TimeseriesDownloader, Union, METADATA_KEY, ME
 from datetime import date, datetime
 from pytz import timezone
 from ..utils import key_handler as key_handler
+from ..utils import logger as log
 import json
 
 GMT = timezone(&#34;GMT&#34;)
@@ -59,7 +60,7 @@ class AVDownloader(TimeseriesDownloader):
         &#39;&#39;&#39;
         self.ts = TimeSeries(api_key, output_format=&#39;pandas&#39;)
 
-    def download_between_dates(self, ticker: str, start: date, end: date, interval: str = &#34;1m&#34;, debug: bool = False) -&gt; Union[dict, bool]:
+    def download_between_dates(self, ticker: str, start: date, end: date, interval: str = &#34;1m&#34;) -&gt; Union[dict, bool]:
         &#39;&#39;&#39;
         Downloads quote data for a single ticker given the start date and end date.
 
@@ -86,16 +87,20 @@ class AVDownloader(TimeseriesDownloader):
                 - datetime (format Y-m-d H:m:s.ms)
                 - other financial values
         &#39;&#39;&#39;
+        log.d(&#34;attempting to download {}&#34;.format(ticker))
+        # Interval standardization (eg. 1m to 1min)
         av_interval = AVDownloader.__standardize_interval(interval)
         try:
             values, meta = self.__call_timeseries_function(
                 ticker=ticker, interval=av_interval, start_date=start)
         except ValueError as exception:
-            if debug:
-                print(&#34;AlphaVantage ValueError: &#34;, exception)
+            log.w(&#34;AlphaVantage ValueError: {}&#34;.format(exception))
             return False
+        log.d(&#34;successfully downloaded {}&#34;.format(ticker))
+        # Convert data from pandas dataframe to JSON
         dict_data = json.loads(values.to_json(orient=&#34;table&#34;))
         atoms = dict_data[&#39;data&#39;]
+        # Fixing atoms datetime
         atoms = AVDownloader.__fix_atoms_datetime(
             atoms=atoms, tz=meta[TIME_ZONE_KEY])
         atoms = key_handler.rename_deep(atoms, AV_ALIASES)
@@ -127,9 +132,12 @@ class AVDownloader(TimeseriesDownloader):
         &#39;&#39;&#39;
 
         if(interval == &#34;1wk&#34;):
+            log.v(&#34;required weekly adjusted&#34;)
             return self.ts.get_weekly_adjusted(symbol=ticker)
         if(interval == &#34;1d&#34;):
+            log.v(&#34;required daily adjusted&#34;)
             return self.ts.get_daily_adjusted(symbol=ticker, outputsize=&#39;full&#39;)
+        log.v(&#34;required intraday&#34;)
         return self.ts.get_intraday(symbol=ticker, outputsize=&#39;full&#39;, interval=interval)
 
     @staticmethod
@@ -157,6 +165,7 @@ class AVDownloader(TimeseriesDownloader):
                 atom[&#39;datetime&#39;], &#34;%Y-%m-%d %H:%M:%S.%f&#34;)
             if(atom_datetime &gt;= start_datetime and atom_datetime &lt;= end_datetime):
                 required_atoms.append(atom)
+        log.v(&#34;atoms filtered by required date&#34;)
         return required_atoms
 
     @staticmethod
@@ -176,6 +185,7 @@ class AVDownloader(TimeseriesDownloader):
         for atom in atoms:
             atom[&#34;datetime&#34;] = AVDownloader.__convert_to_gmt(date_time=datetime.strptime(atom.pop(&#34;date&#34;), &#34;%Y-%m-%dT%H:%M:%S.%fZ&#34;),
                                                              zonename=tz).strftime(&#34;%Y-%m-%d %H:%M:%S.%f&#34;)[:-3]
+        log.v(&#34;changed atoms datetime&#34;)
         return atoms
 
     @staticmethod
@@ -253,7 +263,7 @@ the Alpha Vantage API key to use</p></div>
         &#39;&#39;&#39;
         self.ts = TimeSeries(api_key, output_format=&#39;pandas&#39;)
 
-    def download_between_dates(self, ticker: str, start: date, end: date, interval: str = &#34;1m&#34;, debug: bool = False) -&gt; Union[dict, bool]:
+    def download_between_dates(self, ticker: str, start: date, end: date, interval: str = &#34;1m&#34;) -&gt; Union[dict, bool]:
         &#39;&#39;&#39;
         Downloads quote data for a single ticker given the start date and end date.
 
@@ -280,16 +290,20 @@ the Alpha Vantage API key to use</p></div>
                 - datetime (format Y-m-d H:m:s.ms)
                 - other financial values
         &#39;&#39;&#39;
+        log.d(&#34;attempting to download {}&#34;.format(ticker))
+        # Interval standardization (eg. 1m to 1min)
         av_interval = AVDownloader.__standardize_interval(interval)
         try:
             values, meta = self.__call_timeseries_function(
                 ticker=ticker, interval=av_interval, start_date=start)
         except ValueError as exception:
-            if debug:
-                print(&#34;AlphaVantage ValueError: &#34;, exception)
+            log.w(&#34;AlphaVantage ValueError: {}&#34;.format(exception))
             return False
+        log.d(&#34;successfully downloaded {}&#34;.format(ticker))
+        # Convert data from pandas dataframe to JSON
         dict_data = json.loads(values.to_json(orient=&#34;table&#34;))
         atoms = dict_data[&#39;data&#39;]
+        # Fixing atoms datetime
         atoms = AVDownloader.__fix_atoms_datetime(
             atoms=atoms, tz=meta[TIME_ZONE_KEY])
         atoms = key_handler.rename_deep(atoms, AV_ALIASES)
@@ -321,9 +335,12 @@ the Alpha Vantage API key to use</p></div>
         &#39;&#39;&#39;
 
         if(interval == &#34;1wk&#34;):
+            log.v(&#34;required weekly adjusted&#34;)
             return self.ts.get_weekly_adjusted(symbol=ticker)
         if(interval == &#34;1d&#34;):
+            log.v(&#34;required daily adjusted&#34;)
             return self.ts.get_daily_adjusted(symbol=ticker, outputsize=&#39;full&#39;)
+        log.v(&#34;required intraday&#34;)
         return self.ts.get_intraday(symbol=ticker, outputsize=&#39;full&#39;, interval=interval)
 
     @staticmethod
@@ -351,6 +368,7 @@ the Alpha Vantage API key to use</p></div>
                 atom[&#39;datetime&#39;], &#34;%Y-%m-%d %H:%M:%S.%f&#34;)
             if(atom_datetime &gt;= start_datetime and atom_datetime &lt;= end_datetime):
                 required_atoms.append(atom)
+        log.v(&#34;atoms filtered by required date&#34;)
         return required_atoms
 
     @staticmethod
@@ -370,6 +388,7 @@ the Alpha Vantage API key to use</p></div>
         for atom in atoms:
             atom[&#34;datetime&#34;] = AVDownloader.__convert_to_gmt(date_time=datetime.strptime(atom.pop(&#34;date&#34;), &#34;%Y-%m-%dT%H:%M:%S.%fZ&#34;),
                                                              zonename=tz).strftime(&#34;%Y-%m-%d %H:%M:%S.%f&#34;)[:-3]
+        log.v(&#34;changed atoms datetime&#34;)
         return atoms
 
     @staticmethod
@@ -416,7 +435,7 @@ the Alpha Vantage API key to use</p></div>
 <h3>Methods</h3>
 <dl>
 <dt id="otri.downloader.alphavantage_downloader.AVDownloader.download_between_dates"><code class="name flex">
-<span>def <span class="ident">download_between_dates</span></span>(<span>self, ticker: str, start: datetime.date, end: datetime.date, interval: str = '1m', debug: bool = False) ‑> Union[dict, bool]</span>
+<span>def <span class="ident">download_between_dates</span></span>(<span>self, ticker: str, start: datetime.date, end: datetime.date, interval: str = '1m') ‑> Union[dict, bool]</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Downloads quote data for a single ticker given the start date and end date.</p>
@@ -444,7 +463,7 @@ a dict containing "metadata" and "atoms" otherwise.</p>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def download_between_dates(self, ticker: str, start: date, end: date, interval: str = &#34;1m&#34;, debug: bool = False) -&gt; Union[dict, bool]:
+<pre><code class="python">def download_between_dates(self, ticker: str, start: date, end: date, interval: str = &#34;1m&#34;) -&gt; Union[dict, bool]:
     &#39;&#39;&#39;
     Downloads quote data for a single ticker given the start date and end date.
 
@@ -471,16 +490,20 @@ a dict containing "metadata" and "atoms" otherwise.</p>
             - datetime (format Y-m-d H:m:s.ms)
             - other financial values
     &#39;&#39;&#39;
+    log.d(&#34;attempting to download {}&#34;.format(ticker))
+    # Interval standardization (eg. 1m to 1min)
     av_interval = AVDownloader.__standardize_interval(interval)
     try:
         values, meta = self.__call_timeseries_function(
             ticker=ticker, interval=av_interval, start_date=start)
     except ValueError as exception:
-        if debug:
-            print(&#34;AlphaVantage ValueError: &#34;, exception)
+        log.w(&#34;AlphaVantage ValueError: {}&#34;.format(exception))
         return False
+    log.d(&#34;successfully downloaded {}&#34;.format(ticker))
+    # Convert data from pandas dataframe to JSON
     dict_data = json.loads(values.to_json(orient=&#34;table&#34;))
     atoms = dict_data[&#39;data&#39;]
+    # Fixing atoms datetime
     atoms = AVDownloader.__fix_atoms_datetime(
         atoms=atoms, tz=meta[TIME_ZONE_KEY])
     atoms = key_handler.rename_deep(atoms, AV_ALIASES)

--- a/doc/otri/downloader/gme_downloader.html
+++ b/doc/otri/downloader/gme_downloader.html
@@ -30,6 +30,7 @@
 from collections import OrderedDict
 from .timeseries_downloader import TimeseriesDownloader, Union, METADATA_KEY, META_INTERVAL_KEY, META_PROVIDER_KEY, ATOMS_KEY
 from ..utils import key_handler
+from ..utils import logger as log
 from pytz import timezone
 import json
 import requests
@@ -107,14 +108,14 @@ class GMEDownloader:
             try:
                 dict_data = xmltodict.parse(xml_data)
             except TypeError as error:
-                print(&#34;Error while parsing data {} {}: {}&#34;.format(
+                log.e(&#34;Error while parsing data {} {}: {}&#34;.format(
                     category, req_type, error))
                 return False
             # Format data properly
             formatted_data = GMEDownloader.__prepare_data(
                 dict_data=dict_data)
             if(formatted_data == False):
-                print(json.dumps(dict_data, indent=4))
+                log.i(&#34;formatted data = false, dict_data = {}&#34;.format(json.dumps(dict_data, indent=4)))
             # Merge data from multiple days
             merged_data = GMEDownloader.__merge_data(
                 merged_data, formatted_data)
@@ -141,10 +142,10 @@ class GMEDownloader:
             elif(isinstance(xs_element, list)):
                 req_types = [dict[&#39;@name&#39;] for dict in xs_element]
             else:
-                print(&#34;req_type is non of the above: &#34;, type(xs_element))
+                log.e(&#34;req_type is none of the above: {}&#34;.format(type(xs_element)))
                 return False
         except TypeError as error:
-            print(&#34;Unable to retrieve req_type, &#34;, error)
+            log.e(&#34;Unable to retrieve req_type: {}&#34;.format(error))
             return False
         # Extract atoms in an OrderedDict
         ordered_atoms = dict_data[&#39;NewDataSet&#39;][req_types[0]]
@@ -325,14 +326,14 @@ class GMEDownloader:
             try:
                 dict_data = xmltodict.parse(xml_data)
             except TypeError as error:
-                print(&#34;Error while parsing data {} {}: {}&#34;.format(
+                log.e(&#34;Error while parsing data {} {}: {}&#34;.format(
                     category, req_type, error))
                 return False
             # Format data properly
             formatted_data = GMEDownloader.__prepare_data(
                 dict_data=dict_data)
             if(formatted_data == False):
-                print(json.dumps(dict_data, indent=4))
+                log.i(&#34;formatted data = false, dict_data = {}&#34;.format(json.dumps(dict_data, indent=4)))
             # Merge data from multiple days
             merged_data = GMEDownloader.__merge_data(
                 merged_data, formatted_data)
@@ -359,10 +360,10 @@ class GMEDownloader:
             elif(isinstance(xs_element, list)):
                 req_types = [dict[&#39;@name&#39;] for dict in xs_element]
             else:
-                print(&#34;req_type is non of the above: &#34;, type(xs_element))
+                log.e(&#34;req_type is none of the above: {}&#34;.format(type(xs_element)))
                 return False
         except TypeError as error:
-            print(&#34;Unable to retrieve req_type, &#34;, error)
+            log.e(&#34;Unable to retrieve req_type: {}&#34;.format(error))
             return False
         # Extract atoms in an OrderedDict
         ordered_atoms = dict_data[&#39;NewDataSet&#39;][req_types[0]]
@@ -553,14 +554,14 @@ a dict containing "metadata" and "atoms" otherwise.</p>
         try:
             dict_data = xmltodict.parse(xml_data)
         except TypeError as error:
-            print(&#34;Error while parsing data {} {}: {}&#34;.format(
+            log.e(&#34;Error while parsing data {} {}: {}&#34;.format(
                 category, req_type, error))
             return False
         # Format data properly
         formatted_data = GMEDownloader.__prepare_data(
             dict_data=dict_data)
         if(formatted_data == False):
-            print(json.dumps(dict_data, indent=4))
+            log.i(&#34;formatted data = false, dict_data = {}&#34;.format(json.dumps(dict_data, indent=4)))
         # Merge data from multiple days
         merged_data = GMEDownloader.__merge_data(
             merged_data, formatted_data)

--- a/doc/otri/downloader/yahoo_downloader.html
+++ b/doc/otri/downloader/yahoo_downloader.html
@@ -28,9 +28,10 @@
 </summary>
 <pre><code class="python">from datetime import date, datetime
 from .timeseries_downloader import TimeseriesDownloader, METADATA_KEY, META_INTERVAL_KEY, META_PROVIDER_KEY, META_TICKER_KEY, ATOMS_KEY, Union
+from ..utils import key_handler as key_handler
+from ..utils import logger as log
 import json
 import yfinance as yf
-from ..utils import key_handler as key_handler
 
 META_PROVIDER_VALUE = &#34;yahoo finance&#34;
 
@@ -67,21 +68,27 @@ class YahooDownloader(TimeseriesDownloader):
                 - datetime (format Y-m-d H:m:s.ms)
                 - other financial values
         &#39;&#39;&#39;
-        # yf_data is type of pandas.Dataframe
+        log.d(&#34;attempting to download {}&#34;.format(ticker))
         attempts = 0
         while(attempts &lt; 5):
             try:
+                # yf_data is type of pandas.Dataframe
                 yf_data = yf.download(ticker, start=YahooDownloader.__yahoo_time_format(start), end=YahooDownloader.__yahoo_time_format(
                     end), interval=interval, round=False, progress=False, prepost=True)
                 break
             except Exception as err:
                 attempts+=1
-                print(&#34;There has been an error downloading {} on attempt {}: {}\nTrying again...&#34;, ticker, attempts, err)
-
+                log.w(&#34;There has been an error downloading {} on attempt {}: {}\nTrying again...&#34;.format(ticker, attempts, err))
+                
+        if(attempts &gt;= 4):
+            log.e(&#34;unable to download {}&#34;.format(ticker))
+            return False
         # If no data is downloaded it means that the ticker couldn&#39;t be found or there has been an error, we&#39;re not creating any output file then.
         if yf_data.empty:
+            log.w(&#34;empty downloaded data {}&#34;.format(ticker))
             return False
 
+        log.d(&#34;successfully downloaded {}&#34;.format(ticker))
         return YahooDownloader.__prepare_data(yf_data, ticker, interval)
 
     @staticmethod
@@ -120,6 +127,7 @@ class YahooDownloader(TimeseriesDownloader):
         # Deletion of table headers
         del json_data[&#39;schema&#39;]
 
+        log.v(&#34;finished data standardization&#34;)
         return json_data
 
     @staticmethod
@@ -134,8 +142,8 @@ class YahooDownloader(TimeseriesDownloader):
             List of atoms with standardized datetime.
         &#39;&#39;&#39;
         for atom in atoms:
-            atom[&#39;datetime&#39;] = datetime.strptime(
-                atom[&#39;datetime&#39;], &#34;%Y-%m-%dT%H:%M:%S.%fZ&#34;).strftime(&#34;%Y-%m-%d %H:%M:%S.%f&#34;)[:-3]
+            atom[&#39;datetime&#39;] = datetime.strptime(atom[&#39;datetime&#39;], &#34;%Y-%m-%dT%H:%M:%S.%fZ&#34;).strftime(&#34;%Y-%m-%d %H:%M:%S.%f&#34;)[:-3]
+        log.v(&#34;changed atoms datetime&#34;)
         return atoms</code></pre>
 </details>
 </section>
@@ -189,21 +197,27 @@ class YahooDownloader(TimeseriesDownloader):
                 - datetime (format Y-m-d H:m:s.ms)
                 - other financial values
         &#39;&#39;&#39;
-        # yf_data is type of pandas.Dataframe
+        log.d(&#34;attempting to download {}&#34;.format(ticker))
         attempts = 0
         while(attempts &lt; 5):
             try:
+                # yf_data is type of pandas.Dataframe
                 yf_data = yf.download(ticker, start=YahooDownloader.__yahoo_time_format(start), end=YahooDownloader.__yahoo_time_format(
                     end), interval=interval, round=False, progress=False, prepost=True)
                 break
             except Exception as err:
                 attempts+=1
-                print(&#34;There has been an error downloading {} on attempt {}: {}\nTrying again...&#34;, ticker, attempts, err)
-
+                log.w(&#34;There has been an error downloading {} on attempt {}: {}\nTrying again...&#34;.format(ticker, attempts, err))
+                
+        if(attempts &gt;= 4):
+            log.e(&#34;unable to download {}&#34;.format(ticker))
+            return False
         # If no data is downloaded it means that the ticker couldn&#39;t be found or there has been an error, we&#39;re not creating any output file then.
         if yf_data.empty:
+            log.w(&#34;empty downloaded data {}&#34;.format(ticker))
             return False
 
+        log.d(&#34;successfully downloaded {}&#34;.format(ticker))
         return YahooDownloader.__prepare_data(yf_data, ticker, interval)
 
     @staticmethod
@@ -242,6 +256,7 @@ class YahooDownloader(TimeseriesDownloader):
         # Deletion of table headers
         del json_data[&#39;schema&#39;]
 
+        log.v(&#34;finished data standardization&#34;)
         return json_data
 
     @staticmethod
@@ -256,8 +271,8 @@ class YahooDownloader(TimeseriesDownloader):
             List of atoms with standardized datetime.
         &#39;&#39;&#39;
         for atom in atoms:
-            atom[&#39;datetime&#39;] = datetime.strptime(
-                atom[&#39;datetime&#39;], &#34;%Y-%m-%dT%H:%M:%S.%fZ&#34;).strftime(&#34;%Y-%m-%d %H:%M:%S.%f&#34;)[:-3]
+            atom[&#39;datetime&#39;] = datetime.strptime(atom[&#39;datetime&#39;], &#34;%Y-%m-%dT%H:%M:%S.%fZ&#34;).strftime(&#34;%Y-%m-%d %H:%M:%S.%f&#34;)[:-3]
+        log.v(&#34;changed atoms datetime&#34;)
         return atoms</code></pre>
 </details>
 <h3>Ancestors</h3>
@@ -322,21 +337,27 @@ a dict containing "metadata" and "atoms" otherwise.</p>
             - datetime (format Y-m-d H:m:s.ms)
             - other financial values
     &#39;&#39;&#39;
-    # yf_data is type of pandas.Dataframe
+    log.d(&#34;attempting to download {}&#34;.format(ticker))
     attempts = 0
     while(attempts &lt; 5):
         try:
+            # yf_data is type of pandas.Dataframe
             yf_data = yf.download(ticker, start=YahooDownloader.__yahoo_time_format(start), end=YahooDownloader.__yahoo_time_format(
                 end), interval=interval, round=False, progress=False, prepost=True)
             break
         except Exception as err:
             attempts+=1
-            print(&#34;There has been an error downloading {} on attempt {}: {}\nTrying again...&#34;, ticker, attempts, err)
-
+            log.w(&#34;There has been an error downloading {} on attempt {}: {}\nTrying again...&#34;.format(ticker, attempts, err))
+            
+    if(attempts &gt;= 4):
+        log.e(&#34;unable to download {}&#34;.format(ticker))
+        return False
     # If no data is downloaded it means that the ticker couldn&#39;t be found or there has been an error, we&#39;re not creating any output file then.
     if yf_data.empty:
+        log.w(&#34;empty downloaded data {}&#34;.format(ticker))
         return False
 
+    log.d(&#34;successfully downloaded {}&#34;.format(ticker))
     return YahooDownloader.__prepare_data(yf_data, ticker, interval)</code></pre>
 </details>
 </dd>

--- a/doc/otri/filtering/filter.html
+++ b/doc/otri/filtering/filter.html
@@ -32,14 +32,8 @@ from .stream import Stream
 
 class Filter:
     &#39;&#39;&#39;
-    Abstract class that defines an atom manipulation filter.
-
-    Attributes:
-        input : Sequence[str]
-            Name for input streams. If there are multiple streams the filter must define the right order.
-            Streams will be gathered inside the FilterNet&#39;s dictionary of streams.
-        output : Sequence[str]
-            Name for output streams,
+    Class that defines an atom manipulation filter.
+    To change the order of input streams inspection override the _input_check_order method.
     &#39;&#39;&#39;
 
     def __init__(self, inputs: Sequence[str], outputs: Sequence[str], input_count: int = 0, output_count: int = 0):
@@ -72,6 +66,7 @@ class Filter:
                 output_count, len(outputs)))
         self.__output_names = outputs
         self.__input_names = inputs
+        self._has_outputted = False
 
     def setup(self, inputs: Sequence[Stream], outputs: Sequence[Stream], state: Mapping[str, Any]):
         &#39;&#39;&#39;
@@ -82,7 +77,18 @@ class Filter:
             state : Mapping[str, Any]
                 Dictionary containing states to output.
         &#39;&#39;&#39;
-        raise NotImplementedError(&#34;filter sub-classes must override setup method&#34;)
+        # Save references to streams
+        self.__input_streams = inputs
+        self.__output_streams = outputs
+        self.__state = state
+
+        # Save references to iterators
+        self.__input_iters = list()
+        self.__output_iters = list()
+        for stream in inputs:
+            self.__input_iters.append(iter(stream))
+        for stream in outputs:
+            self.__output_iters.append(iter(stream))
 
     def execute(self):
         &#39;&#39;&#39;
@@ -92,19 +98,138 @@ class Filter:
         - Elaborate it and optionally update its state.
         - If it has produced something, push it into the output streams.
         &#39;&#39;&#39;
-        raise NotImplementedError(&#34;filter sub-classes must override execute method&#34;)
+        # Checks if the filter has finished
+        if self.__are_outputs_closed():
+            self._on_outputs_closed()
+            return
 
-    def get_inputs(self) -&gt; Sequence[str]:
+        self._has_outputted = False
+        # Extracts input data sequentially from each input filter
+        for i in self._input_check_order():
+            if self.__input_iters[i].has_next():
+                self._on_data(next(self.__input_iters[i]),i)
+                return
+
+        # Checks if any of the input streams is still open
+        for input_stream in self.__input_streams:
+            if not input_stream.is_closed():
+                self._on_inputs_empty()
+                return
+        
+        # No more data and all of the inputs closed
+        self._on_inputs_closed()
+
+
+    def get_input_names(self) -&gt; Sequence[str]:
         &#39;&#39;&#39;
         Retrieve the input streams names.
         &#39;&#39;&#39;
         return self.__input_names
 
-    def get_outputs(self) -&gt; Sequence[str]:
+    def get_output_names(self) -&gt; Sequence[str]:
         &#39;&#39;&#39;
         Retrieve the output streams names.
         &#39;&#39;&#39;
-        return self.__output_names</code></pre>
+        return self.__output_names
+
+    def _get_input(self, index: int = 0) -&gt; Stream:
+        &#39;&#39;&#39;
+        Retrieves one specific input stream.
+        &#39;&#39;&#39;
+        return self.__input_streams[index]
+
+    def _get_inputs(self) -&gt; Sequence[Stream]:
+        &#39;&#39;&#39;
+        Retrieves all of the input streams.
+        &#39;&#39;&#39;
+        return self.__input_streams
+
+    def _get_output(self, index: int = 0) -&gt; Stream:
+        &#39;&#39;&#39;
+        Retrieves one specific output stream.
+        &#39;&#39;&#39;
+        return self.__output_streams[index]
+
+    def _get_outputs(self) -&gt; Sequence[Stream]:
+        &#39;&#39;&#39;
+        Retrieves all of the output streams.
+        &#39;&#39;&#39;
+        return self.__output_streams
+
+    def _get_in_iter(self, index: int = 0) -&gt; Stream:
+        &#39;&#39;&#39;
+        Retrieves one specific input stream&#39;s iterator.
+        &#39;&#39;&#39;
+        return self.__input_iters[index]
+
+    def _get_out_iter(self, index: int = 0) -&gt; Stream:
+        &#39;&#39;&#39;
+        Retrieves one specific output stream&#39;s iterator.
+        &#39;&#39;&#39;
+        return self.__output_iters[index]
+
+    def _pop_data(self, index: int = 0) -&gt; Any:
+        &#39;&#39;&#39;
+        Pops one piece of data from an input.
+        &#39;&#39;&#39;
+        return next(self.__input_iters[index])
+
+    def _push_data(self, data: Any, index: int = 0):
+        &#39;&#39;&#39;
+        Pushes one piece of data in an output.
+        &#39;&#39;&#39;
+        self._has_outputted = True
+        self.__output_streams[index].append(data)
+
+    # OVERRIDABLE METHODS
+
+    def _on_outputs_closed(self):
+        &#39;&#39;&#39;
+        Called when all of the outputs have already been closed.
+        &#39;&#39;&#39;
+        pass
+
+    def _on_data(self, data : Any, index : int):
+        &#39;&#39;&#39;
+        Called when one of the inputs has some data and it&#39;s been popped.
+        Input could be still open or closed.
+
+        Parameters:
+            data : Any
+                Popped data from an input.
+            index : int
+                The index of the input the data has been popped from.
+        &#39;&#39;&#39;
+        pass
+
+    def _on_inputs_empty(self):
+        &#39;&#39;&#39;
+        All of the inputs have no data, but not all of them are closed.
+        &#39;&#39;&#39;
+        pass
+
+    def _on_inputs_closed(self):
+        &#39;&#39;&#39;
+        All of the inputs are closed and no more data is available.
+        The filter should empty itself and close all of the output streams.
+        &#39;&#39;&#39;
+        for out_stream in self.__output_streams:
+            out_stream.close()
+    
+    def _input_check_order(self)-&gt;Sequence:
+        &#39;&#39;&#39;
+        Defines the order for the inputs to be checked.
+        By default its just an ordered sequence from 0 to len(inputs).
+        &#39;&#39;&#39;
+        return range(0, len(self.__input_iters))
+
+    # PRIVATE METHODS
+
+    def __are_outputs_closed(self):
+        for stream in self.__output_streams:
+            if not stream.is_closed():
+                return False
+        return True</code></pre>
 </details>
 </section>
 <section>
@@ -121,13 +246,8 @@ class Filter:
 <span>(</span><span>inputs: Sequence[str], outputs: Sequence[str], input_count: int = 0, output_count: int = 0)</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Abstract class that defines an atom manipulation filter.</p>
-<h2 id="attributes">Attributes</h2>
-<p>input : Sequence[str]
-Name for input streams. If there are multiple streams the filter must define the right order.
-Streams will be gathered inside the FilterNet's dictionary of streams.
-output : Sequence[str]
-Name for output streams,</p>
+<div class="desc"><p>Class that defines an atom manipulation filter.
+To change the order of input streams inspection override the _input_check_order method.</p>
 <h2 id="parameters">Parameters</h2>
 <p>inputs : Sequence[str]
 Name for input streams.
@@ -151,14 +271,8 @@ if the given input or output sequence has a different cardinality than expected.
 </summary>
 <pre><code class="python">class Filter:
     &#39;&#39;&#39;
-    Abstract class that defines an atom manipulation filter.
-
-    Attributes:
-        input : Sequence[str]
-            Name for input streams. If there are multiple streams the filter must define the right order.
-            Streams will be gathered inside the FilterNet&#39;s dictionary of streams.
-        output : Sequence[str]
-            Name for output streams,
+    Class that defines an atom manipulation filter.
+    To change the order of input streams inspection override the _input_check_order method.
     &#39;&#39;&#39;
 
     def __init__(self, inputs: Sequence[str], outputs: Sequence[str], input_count: int = 0, output_count: int = 0):
@@ -191,6 +305,7 @@ if the given input or output sequence has a different cardinality than expected.
                 output_count, len(outputs)))
         self.__output_names = outputs
         self.__input_names = inputs
+        self._has_outputted = False
 
     def setup(self, inputs: Sequence[Stream], outputs: Sequence[Stream], state: Mapping[str, Any]):
         &#39;&#39;&#39;
@@ -201,7 +316,18 @@ if the given input or output sequence has a different cardinality than expected.
             state : Mapping[str, Any]
                 Dictionary containing states to output.
         &#39;&#39;&#39;
-        raise NotImplementedError(&#34;filter sub-classes must override setup method&#34;)
+        # Save references to streams
+        self.__input_streams = inputs
+        self.__output_streams = outputs
+        self.__state = state
+
+        # Save references to iterators
+        self.__input_iters = list()
+        self.__output_iters = list()
+        for stream in inputs:
+            self.__input_iters.append(iter(stream))
+        for stream in outputs:
+            self.__output_iters.append(iter(stream))
 
     def execute(self):
         &#39;&#39;&#39;
@@ -211,19 +337,138 @@ if the given input or output sequence has a different cardinality than expected.
         - Elaborate it and optionally update its state.
         - If it has produced something, push it into the output streams.
         &#39;&#39;&#39;
-        raise NotImplementedError(&#34;filter sub-classes must override execute method&#34;)
+        # Checks if the filter has finished
+        if self.__are_outputs_closed():
+            self._on_outputs_closed()
+            return
 
-    def get_inputs(self) -&gt; Sequence[str]:
+        self._has_outputted = False
+        # Extracts input data sequentially from each input filter
+        for i in self._input_check_order():
+            if self.__input_iters[i].has_next():
+                self._on_data(next(self.__input_iters[i]),i)
+                return
+
+        # Checks if any of the input streams is still open
+        for input_stream in self.__input_streams:
+            if not input_stream.is_closed():
+                self._on_inputs_empty()
+                return
+        
+        # No more data and all of the inputs closed
+        self._on_inputs_closed()
+
+
+    def get_input_names(self) -&gt; Sequence[str]:
         &#39;&#39;&#39;
         Retrieve the input streams names.
         &#39;&#39;&#39;
         return self.__input_names
 
-    def get_outputs(self) -&gt; Sequence[str]:
+    def get_output_names(self) -&gt; Sequence[str]:
         &#39;&#39;&#39;
         Retrieve the output streams names.
         &#39;&#39;&#39;
-        return self.__output_names</code></pre>
+        return self.__output_names
+
+    def _get_input(self, index: int = 0) -&gt; Stream:
+        &#39;&#39;&#39;
+        Retrieves one specific input stream.
+        &#39;&#39;&#39;
+        return self.__input_streams[index]
+
+    def _get_inputs(self) -&gt; Sequence[Stream]:
+        &#39;&#39;&#39;
+        Retrieves all of the input streams.
+        &#39;&#39;&#39;
+        return self.__input_streams
+
+    def _get_output(self, index: int = 0) -&gt; Stream:
+        &#39;&#39;&#39;
+        Retrieves one specific output stream.
+        &#39;&#39;&#39;
+        return self.__output_streams[index]
+
+    def _get_outputs(self) -&gt; Sequence[Stream]:
+        &#39;&#39;&#39;
+        Retrieves all of the output streams.
+        &#39;&#39;&#39;
+        return self.__output_streams
+
+    def _get_in_iter(self, index: int = 0) -&gt; Stream:
+        &#39;&#39;&#39;
+        Retrieves one specific input stream&#39;s iterator.
+        &#39;&#39;&#39;
+        return self.__input_iters[index]
+
+    def _get_out_iter(self, index: int = 0) -&gt; Stream:
+        &#39;&#39;&#39;
+        Retrieves one specific output stream&#39;s iterator.
+        &#39;&#39;&#39;
+        return self.__output_iters[index]
+
+    def _pop_data(self, index: int = 0) -&gt; Any:
+        &#39;&#39;&#39;
+        Pops one piece of data from an input.
+        &#39;&#39;&#39;
+        return next(self.__input_iters[index])
+
+    def _push_data(self, data: Any, index: int = 0):
+        &#39;&#39;&#39;
+        Pushes one piece of data in an output.
+        &#39;&#39;&#39;
+        self._has_outputted = True
+        self.__output_streams[index].append(data)
+
+    # OVERRIDABLE METHODS
+
+    def _on_outputs_closed(self):
+        &#39;&#39;&#39;
+        Called when all of the outputs have already been closed.
+        &#39;&#39;&#39;
+        pass
+
+    def _on_data(self, data : Any, index : int):
+        &#39;&#39;&#39;
+        Called when one of the inputs has some data and it&#39;s been popped.
+        Input could be still open or closed.
+
+        Parameters:
+            data : Any
+                Popped data from an input.
+            index : int
+                The index of the input the data has been popped from.
+        &#39;&#39;&#39;
+        pass
+
+    def _on_inputs_empty(self):
+        &#39;&#39;&#39;
+        All of the inputs have no data, but not all of them are closed.
+        &#39;&#39;&#39;
+        pass
+
+    def _on_inputs_closed(self):
+        &#39;&#39;&#39;
+        All of the inputs are closed and no more data is available.
+        The filter should empty itself and close all of the output streams.
+        &#39;&#39;&#39;
+        for out_stream in self.__output_streams:
+            out_stream.close()
+    
+    def _input_check_order(self)-&gt;Sequence:
+        &#39;&#39;&#39;
+        Defines the order for the inputs to be checked.
+        By default its just an ordered sequence from 0 to len(inputs).
+        &#39;&#39;&#39;
+        return range(0, len(self.__input_iters))
+
+    # PRIVATE METHODS
+
+    def __are_outputs_closed(self):
+        for stream in self.__output_streams:
+            if not stream.is_closed():
+                return False
+        return True</code></pre>
 </details>
 <h3>Subclasses</h3>
 <ul class="hlist">
@@ -260,11 +505,30 @@ It should:
     - Elaborate it and optionally update its state.
     - If it has produced something, push it into the output streams.
     &#39;&#39;&#39;
-    raise NotImplementedError(&#34;filter sub-classes must override execute method&#34;)</code></pre>
+    # Checks if the filter has finished
+    if self.__are_outputs_closed():
+        self._on_outputs_closed()
+        return
+
+    self._has_outputted = False
+    # Extracts input data sequentially from each input filter
+    for i in self._input_check_order():
+        if self.__input_iters[i].has_next():
+            self._on_data(next(self.__input_iters[i]),i)
+            return
+
+    # Checks if any of the input streams is still open
+    for input_stream in self.__input_streams:
+        if not input_stream.is_closed():
+            self._on_inputs_empty()
+            return
+    
+    # No more data and all of the inputs closed
+    self._on_inputs_closed()</code></pre>
 </details>
 </dd>
-<dt id="otri.filtering.filter.Filter.get_inputs"><code class="name flex">
-<span>def <span class="ident">get_inputs</span></span>(<span>self) ‑> Sequence[str]</span>
+<dt id="otri.filtering.filter.Filter.get_input_names"><code class="name flex">
+<span>def <span class="ident">get_input_names</span></span>(<span>self) ‑> Sequence[str]</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Retrieve the input streams names.</p></div>
@@ -272,15 +536,15 @@ It should:
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def get_inputs(self) -&gt; Sequence[str]:
+<pre><code class="python">def get_input_names(self) -&gt; Sequence[str]:
     &#39;&#39;&#39;
     Retrieve the input streams names.
     &#39;&#39;&#39;
     return self.__input_names</code></pre>
 </details>
 </dd>
-<dt id="otri.filtering.filter.Filter.get_outputs"><code class="name flex">
-<span>def <span class="ident">get_outputs</span></span>(<span>self) ‑> Sequence[str]</span>
+<dt id="otri.filtering.filter.Filter.get_output_names"><code class="name flex">
+<span>def <span class="ident">get_output_names</span></span>(<span>self) ‑> Sequence[str]</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Retrieve the output streams names.</p></div>
@@ -288,7 +552,7 @@ It should:
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def get_outputs(self) -&gt; Sequence[str]:
+<pre><code class="python">def get_output_names(self) -&gt; Sequence[str]:
     &#39;&#39;&#39;
     Retrieve the output streams names.
     &#39;&#39;&#39;
@@ -318,7 +582,18 @@ Dictionary containing states to output.</p></div>
         state : Mapping[str, Any]
             Dictionary containing states to output.
     &#39;&#39;&#39;
-    raise NotImplementedError(&#34;filter sub-classes must override setup method&#34;)</code></pre>
+    # Save references to streams
+    self.__input_streams = inputs
+    self.__output_streams = outputs
+    self.__state = state
+
+    # Save references to iterators
+    self.__input_iters = list()
+    self.__output_iters = list()
+    for stream in inputs:
+        self.__input_iters.append(iter(stream))
+    for stream in outputs:
+        self.__output_iters.append(iter(stream))</code></pre>
 </details>
 </dd>
 </dl>
@@ -343,8 +618,8 @@ Dictionary containing states to output.</p></div>
 <h4><code><a title="otri.filtering.filter.Filter" href="#otri.filtering.filter.Filter">Filter</a></code></h4>
 <ul class="">
 <li><code><a title="otri.filtering.filter.Filter.execute" href="#otri.filtering.filter.Filter.execute">execute</a></code></li>
-<li><code><a title="otri.filtering.filter.Filter.get_inputs" href="#otri.filtering.filter.Filter.get_inputs">get_inputs</a></code></li>
-<li><code><a title="otri.filtering.filter.Filter.get_outputs" href="#otri.filtering.filter.Filter.get_outputs">get_outputs</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.get_input_names" href="#otri.filtering.filter.Filter.get_input_names">get_input_names</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.get_output_names" href="#otri.filtering.filter.Filter.get_output_names">get_output_names</a></code></li>
 <li><code><a title="otri.filtering.filter.Filter.setup" href="#otri.filtering.filter.Filter.setup">setup</a></code></li>
 </ul>
 </li>

--- a/doc/otri/filtering/filter_layer.html
+++ b/doc/otri/filtering/filter_layer.html
@@ -26,18 +26,38 @@
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">class FilterLayer(list):
+<pre><code class="python">from typing import Collection, Callable
+from .filter import Filter
+
+class FilterLayer:
     &#39;&#39;&#39;
     Defines a list of filters that could be executed in parallel.
     &#39;&#39;&#39;
 
-    def is_finished(self) -&gt; bool:
+    def __init__(self, filters : Collection[Filter], policy : Callable):
+        self.filters = filters
+        self.policy = policy
+    
+    def set_policy(self, policy : Callable):
+        self.policy = policy
+
+    def call_policy(self)-&gt;int:
+        return self.policy(self)
+
+    def has_outputted(self):
+        for f in self.filters:
+            if f._has_outputted:
+                return True
+        return False
+
+    def has_finished(self):
         &#39;&#39;&#39;
-        Retruns whether all the filters in the layer are flagged as finished.
+        Checks if all of the input streams of the filters are closed.
         &#39;&#39;&#39;
-        for fil in super().__iter__():
-            if not fil.is_finished():
-                return False
+        for f in self.filters:
+            for s in f._get_inputs():
+                if not s.is_closed():
+                    return False
         return True</code></pre>
 </details>
 </section>
@@ -52,7 +72,7 @@
 <dl>
 <dt id="otri.filtering.filter_layer.FilterLayer"><code class="flex name class">
 <span>class <span class="ident">FilterLayer</span></span>
-<span>(</span><span>iterable=(), /)</span>
+<span>(</span><span>filters: Collection[<a title="otri.filtering.filter.Filter" href="filter.html#otri.filtering.filter.Filter">Filter</a>], policy: Callable)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Defines a list of filters that could be executed in parallel.</p></div>
@@ -60,43 +80,99 @@
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">class FilterLayer(list):
+<pre><code class="python">class FilterLayer:
     &#39;&#39;&#39;
     Defines a list of filters that could be executed in parallel.
     &#39;&#39;&#39;
 
-    def is_finished(self) -&gt; bool:
+    def __init__(self, filters : Collection[Filter], policy : Callable):
+        self.filters = filters
+        self.policy = policy
+    
+    def set_policy(self, policy : Callable):
+        self.policy = policy
+
+    def call_policy(self)-&gt;int:
+        return self.policy(self)
+
+    def has_outputted(self):
+        for f in self.filters:
+            if f._has_outputted:
+                return True
+        return False
+
+    def has_finished(self):
         &#39;&#39;&#39;
-        Retruns whether all the filters in the layer are flagged as finished.
+        Checks if all of the input streams of the filters are closed.
         &#39;&#39;&#39;
-        for fil in super().__iter__():
-            if not fil.is_finished():
-                return False
+        for f in self.filters:
+            for s in f._get_inputs():
+                if not s.is_closed():
+                    return False
         return True</code></pre>
 </details>
-<h3>Ancestors</h3>
-<ul class="hlist">
-<li>builtins.list</li>
-</ul>
 <h3>Methods</h3>
 <dl>
-<dt id="otri.filtering.filter_layer.FilterLayer.is_finished"><code class="name flex">
-<span>def <span class="ident">is_finished</span></span>(<span>self) ‑> bool</span>
+<dt id="otri.filtering.filter_layer.FilterLayer.call_policy"><code class="name flex">
+<span>def <span class="ident">call_policy</span></span>(<span>self) ‑> int</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Retruns whether all the filters in the layer are flagged as finished.</p></div>
+<div class="desc"></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def is_finished(self) -&gt; bool:
+<pre><code class="python">def call_policy(self)-&gt;int:
+    return self.policy(self)</code></pre>
+</details>
+</dd>
+<dt id="otri.filtering.filter_layer.FilterLayer.has_finished"><code class="name flex">
+<span>def <span class="ident">has_finished</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Checks if all of the input streams of the filters are closed.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def has_finished(self):
     &#39;&#39;&#39;
-    Retruns whether all the filters in the layer are flagged as finished.
+    Checks if all of the input streams of the filters are closed.
     &#39;&#39;&#39;
-    for fil in super().__iter__():
-        if not fil.is_finished():
-            return False
+    for f in self.filters:
+        for s in f._get_inputs():
+            if not s.is_closed():
+                return False
     return True</code></pre>
+</details>
+</dd>
+<dt id="otri.filtering.filter_layer.FilterLayer.has_outputted"><code class="name flex">
+<span>def <span class="ident">has_outputted</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def has_outputted(self):
+    for f in self.filters:
+        if f._has_outputted:
+            return True
+    return False</code></pre>
+</details>
+</dd>
+<dt id="otri.filtering.filter_layer.FilterLayer.set_policy"><code class="name flex">
+<span>def <span class="ident">set_policy</span></span>(<span>self, policy: Callable)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def set_policy(self, policy : Callable):
+    self.policy = policy</code></pre>
 </details>
 </dd>
 </dl>
@@ -120,7 +196,10 @@
 <li>
 <h4><code><a title="otri.filtering.filter_layer.FilterLayer" href="#otri.filtering.filter_layer.FilterLayer">FilterLayer</a></code></h4>
 <ul class="">
-<li><code><a title="otri.filtering.filter_layer.FilterLayer.is_finished" href="#otri.filtering.filter_layer.FilterLayer.is_finished">is_finished</a></code></li>
+<li><code><a title="otri.filtering.filter_layer.FilterLayer.call_policy" href="#otri.filtering.filter_layer.FilterLayer.call_policy">call_policy</a></code></li>
+<li><code><a title="otri.filtering.filter_layer.FilterLayer.has_finished" href="#otri.filtering.filter_layer.FilterLayer.has_finished">has_finished</a></code></li>
+<li><code><a title="otri.filtering.filter_layer.FilterLayer.has_outputted" href="#otri.filtering.filter_layer.FilterLayer.has_outputted">has_outputted</a></code></li>
+<li><code><a title="otri.filtering.filter_layer.FilterLayer.set_policy" href="#otri.filtering.filter_layer.FilterLayer.set_policy">set_policy</a></code></li>
 </ul>
 </li>
 </ul>

--- a/doc/otri/filtering/filter_net.html
+++ b/doc/otri/filtering/filter_net.html
@@ -30,7 +30,6 @@
 from .filter_layer import FilterLayer
 from .stream import Stream
 
-
 class FilterNet:
     &#39;&#39;&#39;
     Ordered collection of filter layers.
@@ -79,25 +78,46 @@ class FilterNet:
         self.stream_dict.update(source)
         # Setup phase
         for filter_layer in self.__layers:
-            for f in filter_layer:
-                f.setup(self.__get_streams_by_names(f.get_inputs()),self.__get_streams_by_names(f.get_outputs()), self.state_dict)
+            for f in filter_layer.filters:
+                f.setup(self.__get_streams_by_names(f.get_input_names()),
+                        self.__get_streams_by_names(f.get_output_names()), self.state_dict)
 
         # Execute phase
-        while(not self.__is_all_finished()):
-            for filter_layer in self.__layers:
-                for fil in filter_layer:
-                    fil.execute()
+        layer_index = 0
+        layer = None
+        while(True):
+            layer = self.__layers[layer_index]
+            # Execute all the filters of the layer
+            for fil in layer.filters:
+                fil.execute()
+            # Check if it&#39;s finished
+            if layer_index &gt;= len(self.__layers) - 1:
+                # Call on_data_output if the last layer has outputted something
+                if on_data_output != None and layer.has_outputted():
+                    for f in layer.filters:
+                        if f._has_outputted:
+                            on_data_output()
+                if self.__is_all_finished():
+                    break
+            # Ask the policy for the new layer index
+            layer_index += layer.call_policy()
+            if(layer_index &gt;= len(self.__layers)):
+                layer_index = 0
+            elif(layer_index &lt; 0):
+                layer_index = 0
+
+        # Returns self for method concatenation
         return self
 
     def streams(self) -&gt; Mapping[str, Stream]:
         &#39;&#39;&#39;
         Retrieves the mapping of streams associated with their names.
-        It&#39;s empty if execute() has never been called
+        It&#39;s empty if execute() has never been called.
         &#39;&#39;&#39;
         return self.stream_dict
 
-    def state(self, key: str, default : Any) -&gt; Any:
-        return self.state_dict.get(key,default)
+    def state(self, key: str, default: Any) -&gt; Any:
+        return self.state_dict.get(key, default)
 
     def __is_all_finished(self) -&gt; bool:
         &#39;&#39;&#39;
@@ -105,8 +125,8 @@ class FilterNet:
         All streams must be initialised inside the self.stream_dict class variable.
         &#39;&#39;&#39;
 
-        for l_filter in self.__layers[len(self.__layers) - 1]:
-            for ouput_stream_name in l_filter.get_outputs():
+        for l_filter in self.__layers[len(self.__layers) - 1].filters:
+            for ouput_stream_name in l_filter.get_output_names():
                 # If even one of the output streams is not closed, then continue execution
                 if not self.stream_dict[ouput_stream_name].is_closed():
                     return False
@@ -121,7 +141,44 @@ class FilterNet:
         for name in names:
             # setdefault(key, default) returns value if key is present, default otherwise and stores key : default in the dict
             streams.append(self.stream_dict.setdefault(name, Stream()))
-        return streams</code></pre>
+        return streams
+
+
+# Policies
+&#39;&#39;&#39;
+Policies:
+A policy is a method that returns a number that represents how many layers skip forward (or backward if the number is negative)
+when  the current layer has been executed.
+If the layer index exceeds the number of layers the next layer is the first one.
+If the layer index is smaller than 0 the next layer is the first one.
+&#39;&#39;&#39;
+
+def EXEC_AND_PASS(layer: FilterLayer):
+    return 1
+
+def EXEC_UNTIL_FINISHED(layer : FilterLayer):
+    for f in layer.filters:
+        for output_stream in f._get_outputs():
+            # If even one of the output streams is not closed, then continue execution of the current layer
+            if not output_stream.is_closed():
+                return 0
+    return 1
+
+def EXEC_UNTIL_OUTPUT(layer : FilterLayer):
+    if layer.has_outputted():
+        return 1
+    return 0
+
+def BACK_IF_NO_OUTPUT(layer : FilterLayer):
+    if layer.has_outputted() or layer.has_finished():
+        # Keep executing if it has outputted anything
+        return 1
+    return -1;
+
+def BACK_IF_OUTPUT(layer : FilterLayer):
+    if layer.has_outputted():
+        return -1
+    return 1</code></pre>
 </details>
 </section>
 <section>
@@ -129,6 +186,86 @@ class FilterNet:
 <section>
 </section>
 <section>
+<h2 class="section-title" id="header-functions">Functions</h2>
+<dl>
+<dt id="otri.filtering.filter_net.BACK_IF_NO_OUTPUT"><code class="name flex">
+<span>def <span class="ident">BACK_IF_NO_OUTPUT</span></span>(<span>layer: <a title="otri.filtering.filter_layer.FilterLayer" href="filter_layer.html#otri.filtering.filter_layer.FilterLayer">FilterLayer</a>)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def BACK_IF_NO_OUTPUT(layer : FilterLayer):
+    if layer.has_outputted() or layer.has_finished():
+        # Keep executing if it has outputted anything
+        return 1
+    return -1;</code></pre>
+</details>
+</dd>
+<dt id="otri.filtering.filter_net.BACK_IF_OUTPUT"><code class="name flex">
+<span>def <span class="ident">BACK_IF_OUTPUT</span></span>(<span>layer: <a title="otri.filtering.filter_layer.FilterLayer" href="filter_layer.html#otri.filtering.filter_layer.FilterLayer">FilterLayer</a>)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def BACK_IF_OUTPUT(layer : FilterLayer):
+    if layer.has_outputted():
+        return -1
+    return 1</code></pre>
+</details>
+</dd>
+<dt id="otri.filtering.filter_net.EXEC_AND_PASS"><code class="name flex">
+<span>def <span class="ident">EXEC_AND_PASS</span></span>(<span>layer: <a title="otri.filtering.filter_layer.FilterLayer" href="filter_layer.html#otri.filtering.filter_layer.FilterLayer">FilterLayer</a>)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def EXEC_AND_PASS(layer: FilterLayer):
+    return 1</code></pre>
+</details>
+</dd>
+<dt id="otri.filtering.filter_net.EXEC_UNTIL_FINISHED"><code class="name flex">
+<span>def <span class="ident">EXEC_UNTIL_FINISHED</span></span>(<span>layer: <a title="otri.filtering.filter_layer.FilterLayer" href="filter_layer.html#otri.filtering.filter_layer.FilterLayer">FilterLayer</a>)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def EXEC_UNTIL_FINISHED(layer : FilterLayer):
+    for f in layer.filters:
+        for output_stream in f._get_outputs():
+            # If even one of the output streams is not closed, then continue execution of the current layer
+            if not output_stream.is_closed():
+                return 0
+    return 1</code></pre>
+</details>
+</dd>
+<dt id="otri.filtering.filter_net.EXEC_UNTIL_OUTPUT"><code class="name flex">
+<span>def <span class="ident">EXEC_UNTIL_OUTPUT</span></span>(<span>layer: <a title="otri.filtering.filter_layer.FilterLayer" href="filter_layer.html#otri.filtering.filter_layer.FilterLayer">FilterLayer</a>)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def EXEC_UNTIL_OUTPUT(layer : FilterLayer):
+    if layer.has_outputted():
+        return 1
+    return 0</code></pre>
+</details>
+</dd>
+</dl>
 </section>
 <section>
 <h2 class="section-title" id="header-classes">Classes</h2>
@@ -200,25 +337,46 @@ All filters must not be empty.</p></div>
         self.stream_dict.update(source)
         # Setup phase
         for filter_layer in self.__layers:
-            for f in filter_layer:
-                f.setup(self.__get_streams_by_names(f.get_inputs()),self.__get_streams_by_names(f.get_outputs()), self.state_dict)
+            for f in filter_layer.filters:
+                f.setup(self.__get_streams_by_names(f.get_input_names()),
+                        self.__get_streams_by_names(f.get_output_names()), self.state_dict)
 
         # Execute phase
-        while(not self.__is_all_finished()):
-            for filter_layer in self.__layers:
-                for fil in filter_layer:
-                    fil.execute()
+        layer_index = 0
+        layer = None
+        while(True):
+            layer = self.__layers[layer_index]
+            # Execute all the filters of the layer
+            for fil in layer.filters:
+                fil.execute()
+            # Check if it&#39;s finished
+            if layer_index &gt;= len(self.__layers) - 1:
+                # Call on_data_output if the last layer has outputted something
+                if on_data_output != None and layer.has_outputted():
+                    for f in layer.filters:
+                        if f._has_outputted:
+                            on_data_output()
+                if self.__is_all_finished():
+                    break
+            # Ask the policy for the new layer index
+            layer_index += layer.call_policy()
+            if(layer_index &gt;= len(self.__layers)):
+                layer_index = 0
+            elif(layer_index &lt; 0):
+                layer_index = 0
+
+        # Returns self for method concatenation
         return self
 
     def streams(self) -&gt; Mapping[str, Stream]:
         &#39;&#39;&#39;
         Retrieves the mapping of streams associated with their names.
-        It&#39;s empty if execute() has never been called
+        It&#39;s empty if execute() has never been called.
         &#39;&#39;&#39;
         return self.stream_dict
 
-    def state(self, key: str, default : Any) -&gt; Any:
-        return self.state_dict.get(key,default)
+    def state(self, key: str, default: Any) -&gt; Any:
+        return self.state_dict.get(key, default)
 
     def __is_all_finished(self) -&gt; bool:
         &#39;&#39;&#39;
@@ -226,8 +384,8 @@ All filters must not be empty.</p></div>
         All streams must be initialised inside the self.stream_dict class variable.
         &#39;&#39;&#39;
 
-        for l_filter in self.__layers[len(self.__layers) - 1]:
-            for ouput_stream_name in l_filter.get_outputs():
+        for l_filter in self.__layers[len(self.__layers) - 1].filters:
+            for ouput_stream_name in l_filter.get_output_names():
                 # If even one of the output streams is not closed, then continue execution
                 if not self.stream_dict[ouput_stream_name].is_closed():
                     return False
@@ -296,14 +454,35 @@ Function called everytime any filter from the last layer outputs something in an
     self.stream_dict.update(source)
     # Setup phase
     for filter_layer in self.__layers:
-        for f in filter_layer:
-            f.setup(self.__get_streams_by_names(f.get_inputs()),self.__get_streams_by_names(f.get_outputs()), self.state_dict)
+        for f in filter_layer.filters:
+            f.setup(self.__get_streams_by_names(f.get_input_names()),
+                    self.__get_streams_by_names(f.get_output_names()), self.state_dict)
 
     # Execute phase
-    while(not self.__is_all_finished()):
-        for filter_layer in self.__layers:
-            for fil in filter_layer:
-                fil.execute()
+    layer_index = 0
+    layer = None
+    while(True):
+        layer = self.__layers[layer_index]
+        # Execute all the filters of the layer
+        for fil in layer.filters:
+            fil.execute()
+        # Check if it&#39;s finished
+        if layer_index &gt;= len(self.__layers) - 1:
+            # Call on_data_output if the last layer has outputted something
+            if on_data_output != None and layer.has_outputted():
+                for f in layer.filters:
+                    if f._has_outputted:
+                        on_data_output()
+            if self.__is_all_finished():
+                break
+        # Ask the policy for the new layer index
+        layer_index += layer.call_policy()
+        if(layer_index &gt;= len(self.__layers)):
+            layer_index = 0
+        elif(layer_index &lt; 0):
+            layer_index = 0
+
+    # Returns self for method concatenation
     return self</code></pre>
 </details>
 </dd>
@@ -316,8 +495,8 @@ Function called everytime any filter from the last layer outputs something in an
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def state(self, key: str, default : Any) -&gt; Any:
-    return self.state_dict.get(key,default)</code></pre>
+<pre><code class="python">def state(self, key: str, default: Any) -&gt; Any:
+    return self.state_dict.get(key, default)</code></pre>
 </details>
 </dd>
 <dt id="otri.filtering.filter_net.FilterNet.streams"><code class="name flex">
@@ -325,7 +504,7 @@ Function called everytime any filter from the last layer outputs something in an
 </code></dt>
 <dd>
 <div class="desc"><p>Retrieves the mapping of streams associated with their names.
-It's empty if execute() has never been called</p></div>
+It's empty if execute() has never been called.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -333,7 +512,7 @@ It's empty if execute() has never been called</p></div>
 <pre><code class="python">def streams(self) -&gt; Mapping[str, Stream]:
     &#39;&#39;&#39;
     Retrieves the mapping of streams associated with their names.
-    It&#39;s empty if execute() has never been called
+    It&#39;s empty if execute() has never been called.
     &#39;&#39;&#39;
     return self.stream_dict</code></pre>
 </details>
@@ -352,6 +531,15 @@ It's empty if execute() has never been called</p></div>
 <li><h3>Super-module</h3>
 <ul>
 <li><code><a title="otri.filtering" href="index.html">otri.filtering</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-functions">Functions</a></h3>
+<ul class="">
+<li><code><a title="otri.filtering.filter_net.BACK_IF_NO_OUTPUT" href="#otri.filtering.filter_net.BACK_IF_NO_OUTPUT">BACK_IF_NO_OUTPUT</a></code></li>
+<li><code><a title="otri.filtering.filter_net.BACK_IF_OUTPUT" href="#otri.filtering.filter_net.BACK_IF_OUTPUT">BACK_IF_OUTPUT</a></code></li>
+<li><code><a title="otri.filtering.filter_net.EXEC_AND_PASS" href="#otri.filtering.filter_net.EXEC_AND_PASS">EXEC_AND_PASS</a></code></li>
+<li><code><a title="otri.filtering.filter_net.EXEC_UNTIL_FINISHED" href="#otri.filtering.filter_net.EXEC_UNTIL_FINISHED">EXEC_UNTIL_FINISHED</a></code></li>
+<li><code><a title="otri.filtering.filter_net.EXEC_UNTIL_OUTPUT" href="#otri.filtering.filter_net.EXEC_UNTIL_OUTPUT">EXEC_UNTIL_OUTPUT</a></code></li>
 </ul>
 </li>
 <li><h3><a href="#header-classes">Classes</a></h3>

--- a/doc/otri/filtering/filters/generic_filter.html
+++ b/doc/otri/filtering/filters/generic_filter.html
@@ -32,9 +32,9 @@ from typing import Callable
 
 class GenericFilter(Filter):
     &#39;&#39;&#39;
-    Applies a given Callable to all input data and outputs them in the output stream.
-    
-    Input:
+    Applies a given Callable to all data that passes through.
+
+    Inputs:
         Single stream.
     Outputs:
         Single stream.
@@ -58,35 +58,11 @@ class GenericFilter(Filter):
         )
         self.__operation = operation
 
-    def setup(self, inputs : Sequence[Stream], outputs : Sequence[Stream], state: Mapping[str, Any]):
+    def _on_data(self, data: Any, index: int):
         &#39;&#39;&#39;
-        Used to save references to streams and reset variables.
-        Called once before the start of the execution in FilterNet.
-        
-        Parameters:
-            inputs, outputs : Sequence[Stream]
-                Ordered sequence containing the required input/output streams gained from the FilterNet.
-            state : Mapping[str, Any]
-                Dictionary containing states to output.
+        Applies the operation on the atom then pushes it into the output
         &#39;&#39;&#39;
-        self.__input = inputs[0]
-        self.__input_iter = iter(inputs[0])
-        self.__output = outputs[0]
-
-    def execute(self):
-        &#39;&#39;&#39;
-        Method called when a single step in the filtering must be taken.
-        If the input stream has another item, the operation init parameter will be
-        applied to it, and its return value will be put in the output stream.
-        &#39;&#39;&#39;
-        if self.__output.is_closed():
-            return
-
-        if self.__input_iter.has_next():
-            item = next(self.__input_iter)
-            self.__output.append(self.__operation(item))
-        elif self.__input.is_closed():
-            self.__output.close()</code></pre>
+        self._push_data(self.__operation(data))</code></pre>
 </details>
 </section>
 <section>
@@ -103,8 +79,8 @@ class GenericFilter(Filter):
 <span>(</span><span>inputs: str, outputs: str, operation: Callable)</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Applies a given Callable to all input data and outputs them in the output stream.</p>
-<h2 id="input">Input</h2>
+<div class="desc"><p>Applies a given Callable to all data that passes through.</p>
+<h2 id="inputs">Inputs</h2>
 <p>Single stream.</p>
 <h2 id="outputs">Outputs</h2>
 <p>Single stream.</p>
@@ -121,9 +97,9 @@ The operation that must be applied to the data of the input stream.</p></div>
 </summary>
 <pre><code class="python">class GenericFilter(Filter):
     &#39;&#39;&#39;
-    Applies a given Callable to all input data and outputs them in the output stream.
-    
-    Input:
+    Applies a given Callable to all data that passes through.
+
+    Inputs:
         Single stream.
     Outputs:
         Single stream.
@@ -147,107 +123,24 @@ The operation that must be applied to the data of the input stream.</p></div>
         )
         self.__operation = operation
 
-    def setup(self, inputs : Sequence[Stream], outputs : Sequence[Stream], state: Mapping[str, Any]):
+    def _on_data(self, data: Any, index: int):
         &#39;&#39;&#39;
-        Used to save references to streams and reset variables.
-        Called once before the start of the execution in FilterNet.
-        
-        Parameters:
-            inputs, outputs : Sequence[Stream]
-                Ordered sequence containing the required input/output streams gained from the FilterNet.
-            state : Mapping[str, Any]
-                Dictionary containing states to output.
+        Applies the operation on the atom then pushes it into the output
         &#39;&#39;&#39;
-        self.__input = inputs[0]
-        self.__input_iter = iter(inputs[0])
-        self.__output = outputs[0]
-
-    def execute(self):
-        &#39;&#39;&#39;
-        Method called when a single step in the filtering must be taken.
-        If the input stream has another item, the operation init parameter will be
-        applied to it, and its return value will be put in the output stream.
-        &#39;&#39;&#39;
-        if self.__output.is_closed():
-            return
-
-        if self.__input_iter.has_next():
-            item = next(self.__input_iter)
-            self.__output.append(self.__operation(item))
-        elif self.__input.is_closed():
-            self.__output.close()</code></pre>
+        self._push_data(self.__operation(data))</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="otri.filtering.filter.Filter" href="../filter.html#otri.filtering.filter.Filter">Filter</a></li>
 </ul>
-<h3>Methods</h3>
-<dl>
-<dt id="otri.filtering.filters.generic_filter.GenericFilter.execute"><code class="name flex">
-<span>def <span class="ident">execute</span></span>(<span>self)</span>
-</code></dt>
-<dd>
-<div class="desc"><p>Method called when a single step in the filtering must be taken.
-If the input stream has another item, the operation init parameter will be
-applied to it, and its return value will be put in the output stream.</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def execute(self):
-    &#39;&#39;&#39;
-    Method called when a single step in the filtering must be taken.
-    If the input stream has another item, the operation init parameter will be
-    applied to it, and its return value will be put in the output stream.
-    &#39;&#39;&#39;
-    if self.__output.is_closed():
-        return
-
-    if self.__input_iter.has_next():
-        item = next(self.__input_iter)
-        self.__output.append(self.__operation(item))
-    elif self.__input.is_closed():
-        self.__output.close()</code></pre>
-</details>
-</dd>
-<dt id="otri.filtering.filters.generic_filter.GenericFilter.setup"><code class="name flex">
-<span>def <span class="ident">setup</span></span>(<span>self, inputs: Sequence[<a title="otri.filtering.stream.Stream" href="../stream.html#otri.filtering.stream.Stream">Stream</a>], outputs: Sequence[<a title="otri.filtering.stream.Stream" href="../stream.html#otri.filtering.stream.Stream">Stream</a>], state: Mapping[str, Any])</span>
-</code></dt>
-<dd>
-<div class="desc"><p>Used to save references to streams and reset variables.
-Called once before the start of the execution in FilterNet.</p>
-<h2 id="parameters">Parameters</h2>
-<p>inputs, outputs : Sequence[Stream]
-Ordered sequence containing the required input/output streams gained from the FilterNet.
-state : Mapping[str, Any]
-Dictionary containing states to output.</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def setup(self, inputs : Sequence[Stream], outputs : Sequence[Stream], state: Mapping[str, Any]):
-    &#39;&#39;&#39;
-    Used to save references to streams and reset variables.
-    Called once before the start of the execution in FilterNet.
-    
-    Parameters:
-        inputs, outputs : Sequence[Stream]
-            Ordered sequence containing the required input/output streams gained from the FilterNet.
-        state : Mapping[str, Any]
-            Dictionary containing states to output.
-    &#39;&#39;&#39;
-    self.__input = inputs[0]
-    self.__input_iter = iter(inputs[0])
-    self.__output = outputs[0]</code></pre>
-</details>
-</dd>
-</dl>
 <h3>Inherited members</h3>
 <ul class="hlist">
 <li><code><b><a title="otri.filtering.filter.Filter" href="../filter.html#otri.filtering.filter.Filter">Filter</a></b></code>:
 <ul class="hlist">
-<li><code><a title="otri.filtering.filter.Filter.get_inputs" href="../filter.html#otri.filtering.filter.Filter.get_inputs">get_inputs</a></code></li>
-<li><code><a title="otri.filtering.filter.Filter.get_outputs" href="../filter.html#otri.filtering.filter.Filter.get_outputs">get_outputs</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.execute" href="../filter.html#otri.filtering.filter.Filter.execute">execute</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.get_input_names" href="../filter.html#otri.filtering.filter.Filter.get_input_names">get_input_names</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.get_output_names" href="../filter.html#otri.filtering.filter.Filter.get_output_names">get_output_names</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.setup" href="../filter.html#otri.filtering.filter.Filter.setup">setup</a></code></li>
 </ul>
 </li>
 </ul>
@@ -270,10 +163,6 @@ Dictionary containing states to output.</p></div>
 <ul>
 <li>
 <h4><code><a title="otri.filtering.filters.generic_filter.GenericFilter" href="#otri.filtering.filters.generic_filter.GenericFilter">GenericFilter</a></code></h4>
-<ul class="">
-<li><code><a title="otri.filtering.filters.generic_filter.GenericFilter.execute" href="#otri.filtering.filters.generic_filter.GenericFilter.execute">execute</a></code></li>
-<li><code><a title="otri.filtering.filters.generic_filter.GenericFilter.setup" href="#otri.filtering.filters.generic_filter.GenericFilter.setup">setup</a></code></li>
-</ul>
 </li>
 </ul>
 </li>

--- a/doc/otri/filtering/filters/interpolation_filter.html
+++ b/doc/otri/filtering/filters/interpolation_filter.html
@@ -28,28 +28,23 @@
 </summary>
 <pre><code class="python">from ..filter import Filter, Stream, Sequence, Any, Mapping
 from typing import Collection
-from datetime import timedelta
+from datetime import timedelta, datetime, time, date
 from ...utils import time_handler as th
-
-TIMEDELTA_DICT: dict = {
-    &#34;seconds&#34;: timedelta(seconds=1),
-    &#34;minutes&#34;: timedelta(minutes=1),
-    &#34;hours&#34;: timedelta(hours=1),
-    &#34;days&#34;: timedelta(days=1)
-}
+from numpy import interp
 
 
 class InterpolationFilter(Filter):
     &#39;&#39;&#39;
     Interpolates value between two stream atoms if their time difference is greater than a given maximum interval.
     The resulting atoms will have given values interpolated.
-    Input:
+
+    Inputs:
         Oredered by datetime atoms.
-    Output:
-        Atoms interpolated for the given target interval
+    Outputs:
+        Atoms interpolated at the desired frequency.
     &#39;&#39;&#39;
 
-    def __init__(self, inputs: str, outputs: str, keys_to_interp: Collection[str], target_interval: str = &#34;minutes&#34;):
+    def __init__(self, inputs: str, outputs: str, keys_to_interp: Collection[str]):
         &#39;&#39;&#39;
         Parameters:
             inputs : str
@@ -58,9 +53,10 @@ class InterpolationFilter(Filter):
                 Output stream name.
             keys_to_interp : Collection[str]
                 Collection of keys to update when calculating interpolation. Will be the only keys of the atoms (with datetime too).
-            target_interval : str
-                The maximum interval between successive atoms.
-                Could be &#34;seconds&#34;, &#34;minutes&#34;, &#34;hours&#34;, &#34;days&#34;.
+            target_gap_seconds : str
+                The target gap between atoms in seconds.
+            working_hours : tuple(start, end)
+                Tuple containing datetime for start hour minutes and seconds and end time. Values will be calculated inside these working hours only.
         &#39;&#39;&#39;
         super().__init__(
             inputs=[inputs],
@@ -68,91 +64,120 @@ class InterpolationFilter(Filter):
             input_count=1,
             output_count=1
         )
-        self.target_interval = target_interval
         self.keys_to_interp = keys_to_interp
-        self.timeunit = InterpolationFilter.__timedelta_from_interval(
-            interval=target_interval)
         self.atom_buffer = None
 
-    def setup(self, inputs: Sequence[Stream], outputs: Sequence[Stream], state: Mapping[str, Any]):
-        &#39;&#39;&#39;
-        Used to save references to streams and reset variables.
-        Called once before the start of the execution in FilterNet.
-
-        Parameters:
-            inputs, outputs : Sequence[Stream]
-                Ordered sequence containing the required input/output streams gained from the FilterNet.
-            state : Mapping[str, Any]
-                Dictionary containing states to output.
-        &#39;&#39;&#39;
-        self.__input = inputs[0]
-        self.__input_iter = iter(inputs[0])
-        self.__output = outputs[0]
-
-    def execute(self):
+    def _on_data(self, data, index):
         &#39;&#39;&#39;
         Waits for two atoms and interpolates the given dictionary values.
         &#39;&#39;&#39;
-        if self.__output.is_closed():
-            return
+        if(self.atom_buffer == None):
+            # Do nothing, just save the atom for the next iteration
+            self.atom_buffer = data
+        else:
+            output_atoms = self._create_atoms(data)
+            for atom in output_atoms:
+                self._push_data(atom)
 
-        if self.__input_iter.has_next():
-            atom = next(self.__input_iter)
-            if(self.atom_buffer == None):
-                # Do nothing, just save the atom for the next
-                self.atom_buffer = atom
-            else:
-                self.__create_missing_atoms(atom, self.__output)
-        elif(self.__input.is_closed()):
-            # Empty the atom_buffer (should contain one atom)
-            if(self.atom_buffer != None):
-                self.__output.append(self.atom_buffer)
-                self.atom_buffer = None
-            self.__output.close()
-
-    def __create_missing_atoms(self, atom: dict, output: Stream):
+    def _on_inputs_closed(self):
         &#39;&#39;&#39;
-        Pushes into the output stream the current self.atom_buffer and all the interpolated atoms between that and the give atom.
+        Pushes out the atom in the buffer and closes the outputs
         &#39;&#39;&#39;
-        atom1_datetime = th.str_to_datetime(self.atom_buffer[&#39;datetime&#39;])
-        atom2_datetime = th.str_to_datetime(atom[&#39;datetime&#39;])
-        atom12_dt_diff = (atom2_datetime - atom1_datetime).total_seconds()
-        new_atom_datetime = atom1_datetime + self.timeunit
+        if(self.atom_buffer != None):
+            self._push_data(self.atom_buffer)
+            self.atom_buffer = None
+        super()._on_inputs_closed()
 
-        # Place the current atom_buffer into the output
-        output.append(self.atom_buffer)
+    def _create_atoms(self, B: dict) -&gt; Sequence[dict]:
+        raise NotImplementedError()
 
-        while(new_atom_datetime &lt; atom2_datetime):
-            new_atom = {}
-            new_atom[&#39;datetime&#39;] = th.datetime_to_str(new_atom_datetime)
-            progress = (new_atom_datetime -
-                        atom1_datetime).total_seconds() / atom12_dt_diff
+
+class IntradayInterpolationFilter(InterpolationFilter):
+    &#39;&#39;&#39;
+    Interpolates value between two stream atoms if their time difference is greater than a given maximum interval.
+    The resulting atoms will have given values interpolated.\n
+
+    Inputs:\n
+        Oredered by datetime atoms.\n
+    Outputs:\n
+        Atoms interpolated at the desired frequency.\n
+    &#39;&#39;&#39;
+
+    def __init__(self, inputs: str, outputs: str, keys_to_interp: Collection[str], target_gap_seconds: int = 60, working_hours: tuple = (time(hour=8), time(hour=20))):
+        &#39;&#39;&#39;
+        Parameters:\n
+            inputs : str\n
+                Input stream name.\n
+            outputs : str\n
+                Output stream name.\n
+            keys_to_interp : Collection[str]\n
+                Collection of keys to update when calculating interpolation. Will be the only keys of the atoms (with datetime too).\n
+            target_gap_seconds : str\n
+                The target gap between atoms in seconds.\n
+            working_hours : tuple(start, end)\n
+                Tuple containing datetime.time for start hour minutes and seconds and end time. Values will be calculated inside these working hours only.
+                The start time must be earlier than end time by at least one target_gap_seconds seconds\n
+        &#39;&#39;&#39;
+        super().__init__(
+            inputs=inputs,
+            outputs=outputs,
+            keys_to_interp=keys_to_interp
+        )
+        self.__gap_datetime = timedelta(seconds=target_gap_seconds)
+        self.__working_hours = working_hours
+        # Iterates through time of the day and resets on a new day
+        self.__instant_iterator = working_hours[0]
+
+    def _create_atoms(self, B: dict) -&gt; Any:
+        &#39;&#39;&#39;
+        Pushes into the output stream the current self.atom_buffer and all the interpolated atoms between that and the give atom.\n
+        &#39;&#39;&#39;
+        A_datetime = th.str_to_datetime(self.atom_buffer[&#39;datetime&#39;])
+        B_datetime = th.str_to_datetime(B[&#39;datetime&#39;])
+        A_epoch = th.datetime_to_epoch(A_datetime)
+        B_epoch = th.datetime_to_epoch(B_datetime)
+
+        interp_instants = []
+
+        # Interpolate from the starting hour for the first atom
+        if not hasattr(self, &#34;cur_day&#34;):
+            self.cur_day = A_datetime.date()
+            self.__instant_iterator = self.__working_hours[0]
+
+        while(self.__instant_iterator &lt;= th.datetime_to_time(A_datetime) and self.__instant_iterator &lt;= self.__working_hours[1]):
+            interp_instants.append(th.datetime_to_epoch(datetime.combine(A_datetime.date(), self.__instant_iterator)))
+            self.__instant_iterator = th.sum_time(self.__instant_iterator, self.__gap_datetime)
+        
+        # Interpolate between the two atoms
+        while(self.cur_day &lt; B_datetime.date()):
+            while(self.__instant_iterator &lt;= self.__working_hours[1]):
+                interp_instants.append(th.datetime_to_epoch(datetime.combine(self.cur_day, self.__instant_iterator)))
+                self.__instant_iterator = th.sum_time(self.__instant_iterator, self.__gap_datetime)
+            self.cur_day += timedelta(days=1)
+            self.__instant_iterator = self.__working_hours[0]
+
+        # Reached the B day
+        while(self.__instant_iterator &lt;= th.datetime_to_time(B_datetime) and self.__instant_iterator &lt;= self.__working_hours[1]):
+            interp_instants.append(th.datetime_to_epoch(datetime.combine(self.cur_day, self.__instant_iterator)))
+            self.__instant_iterator = th.sum_time(self.__instant_iterator, self.__gap_datetime)
+            
+        output_atoms = []
+        interp_values = {}
+        for key in self.keys_to_interp:
+            interp_values[key] = interp(
+                x = interp_instants,
+                xp = [A_epoch, B_epoch],
+                fp = [float(self.atom_buffer[key]), float(B[key])]
+            )
+        
+        for i in range(len(interp_instants)):
+            atom = {}
+            atom[&#39;datetime&#39;] = th.datetime_to_str(datetime.utcfromtimestamp(interp_instants[i]))
             for key in self.keys_to_interp:
-                new_atom[key] = self.atom_buffer[key] + \
-                    (atom[key] - self.atom_buffer[key]) * progress
-            output.append(new_atom)
+                atom[key] = interp_values[key][i]
+            output_atoms.append(atom)
 
-            new_atom_datetime = new_atom_datetime + self.timeunit
-        self.atom_buffer = atom
-
-    @staticmethod
-    def __timedelta_from_interval(interval: str) -&gt; timedelta:
-        &#39;&#39;&#39;
-        Returns the unit timedelta given the interval.
-
-        Parameters:
-            interval : str
-                The interval to use to calculate the number of datetimes between the two give atoms&#39;.
-                Could be &#34;seconds&#34;, &#34;minutes&#34;, &#34;hours&#34;, &#34;days&#34;.
-        Returns:
-            datetime.timedelta
-        Raises:
-            ValueError if the interval is not supported
-        &#39;&#39;&#39;
-        value = TIMEDELTA_DICT.get(interval, None)
-        if(value == None):
-            raise ValueError(&#34;Interval {} is not supported&#34;.format(interval))
-        return value</code></pre>
+        return output_atoms</code></pre>
 </details>
 </section>
 <section>
@@ -166,15 +191,15 @@ class InterpolationFilter(Filter):
 <dl>
 <dt id="otri.filtering.filters.interpolation_filter.InterpolationFilter"><code class="flex name class">
 <span>class <span class="ident">InterpolationFilter</span></span>
-<span>(</span><span>inputs: str, outputs: str, keys_to_interp: Collection[str], target_interval: str = 'minutes')</span>
+<span>(</span><span>inputs: str, outputs: str, keys_to_interp: Collection[str])</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Interpolates value between two stream atoms if their time difference is greater than a given maximum interval.
 The resulting atoms will have given values interpolated.</p>
-<h2 id="input">Input</h2>
+<h2 id="inputs">Inputs</h2>
 <p>Oredered by datetime atoms.</p>
-<h2 id="output">Output</h2>
-<p>Atoms interpolated for the given target interval</p>
+<h2 id="outputs">Outputs</h2>
+<p>Atoms interpolated at the desired frequency.</p>
 <h2 id="parameters">Parameters</h2>
 <p>inputs : str
 Input stream name.
@@ -182,9 +207,10 @@ outputs : str
 Output stream name.
 keys_to_interp : Collection[str]
 Collection of keys to update when calculating interpolation. Will be the only keys of the atoms (with datetime too).
-target_interval : str
-The maximum interval between successive atoms.
-Could be "seconds", "minutes", "hours", "days".</p></div>
+target_gap_seconds : str
+The target gap between atoms in seconds.
+working_hours : tuple(start, end)
+Tuple containing datetime for start hour minutes and seconds and end time. Values will be calculated inside these working hours only.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -193,13 +219,14 @@ Could be "seconds", "minutes", "hours", "days".</p></div>
     &#39;&#39;&#39;
     Interpolates value between two stream atoms if their time difference is greater than a given maximum interval.
     The resulting atoms will have given values interpolated.
-    Input:
+
+    Inputs:
         Oredered by datetime atoms.
-    Output:
-        Atoms interpolated for the given target interval
+    Outputs:
+        Atoms interpolated at the desired frequency.
     &#39;&#39;&#39;
 
-    def __init__(self, inputs: str, outputs: str, keys_to_interp: Collection[str], target_interval: str = &#34;minutes&#34;):
+    def __init__(self, inputs: str, outputs: str, keys_to_interp: Collection[str]):
         &#39;&#39;&#39;
         Parameters:
             inputs : str
@@ -208,9 +235,10 @@ Could be "seconds", "minutes", "hours", "days".</p></div>
                 Output stream name.
             keys_to_interp : Collection[str]
                 Collection of keys to update when calculating interpolation. Will be the only keys of the atoms (with datetime too).
-            target_interval : str
-                The maximum interval between successive atoms.
-                Could be &#34;seconds&#34;, &#34;minutes&#34;, &#34;hours&#34;, &#34;days&#34;.
+            target_gap_seconds : str
+                The target gap between atoms in seconds.
+            working_hours : tuple(start, end)
+                Tuple containing datetime for start hour minutes and seconds and end time. Values will be calculated inside these working hours only.
         &#39;&#39;&#39;
         super().__init__(
             inputs=[inputs],
@@ -218,167 +246,185 @@ Could be "seconds", "minutes", "hours", "days".</p></div>
             input_count=1,
             output_count=1
         )
-        self.target_interval = target_interval
         self.keys_to_interp = keys_to_interp
-        self.timeunit = InterpolationFilter.__timedelta_from_interval(
-            interval=target_interval)
         self.atom_buffer = None
 
-    def setup(self, inputs: Sequence[Stream], outputs: Sequence[Stream], state: Mapping[str, Any]):
-        &#39;&#39;&#39;
-        Used to save references to streams and reset variables.
-        Called once before the start of the execution in FilterNet.
-
-        Parameters:
-            inputs, outputs : Sequence[Stream]
-                Ordered sequence containing the required input/output streams gained from the FilterNet.
-            state : Mapping[str, Any]
-                Dictionary containing states to output.
-        &#39;&#39;&#39;
-        self.__input = inputs[0]
-        self.__input_iter = iter(inputs[0])
-        self.__output = outputs[0]
-
-    def execute(self):
+    def _on_data(self, data, index):
         &#39;&#39;&#39;
         Waits for two atoms and interpolates the given dictionary values.
         &#39;&#39;&#39;
-        if self.__output.is_closed():
-            return
+        if(self.atom_buffer == None):
+            # Do nothing, just save the atom for the next iteration
+            self.atom_buffer = data
+        else:
+            output_atoms = self._create_atoms(data)
+            for atom in output_atoms:
+                self._push_data(atom)
 
-        if self.__input_iter.has_next():
-            atom = next(self.__input_iter)
-            if(self.atom_buffer == None):
-                # Do nothing, just save the atom for the next
-                self.atom_buffer = atom
-            else:
-                self.__create_missing_atoms(atom, self.__output)
-        elif(self.__input.is_closed()):
-            # Empty the atom_buffer (should contain one atom)
-            if(self.atom_buffer != None):
-                self.__output.append(self.atom_buffer)
-                self.atom_buffer = None
-            self.__output.close()
-
-    def __create_missing_atoms(self, atom: dict, output: Stream):
+    def _on_inputs_closed(self):
         &#39;&#39;&#39;
-        Pushes into the output stream the current self.atom_buffer and all the interpolated atoms between that and the give atom.
+        Pushes out the atom in the buffer and closes the outputs
         &#39;&#39;&#39;
-        atom1_datetime = th.str_to_datetime(self.atom_buffer[&#39;datetime&#39;])
-        atom2_datetime = th.str_to_datetime(atom[&#39;datetime&#39;])
-        atom12_dt_diff = (atom2_datetime - atom1_datetime).total_seconds()
-        new_atom_datetime = atom1_datetime + self.timeunit
+        if(self.atom_buffer != None):
+            self._push_data(self.atom_buffer)
+            self.atom_buffer = None
+        super()._on_inputs_closed()
 
-        # Place the current atom_buffer into the output
-        output.append(self.atom_buffer)
-
-        while(new_atom_datetime &lt; atom2_datetime):
-            new_atom = {}
-            new_atom[&#39;datetime&#39;] = th.datetime_to_str(new_atom_datetime)
-            progress = (new_atom_datetime -
-                        atom1_datetime).total_seconds() / atom12_dt_diff
-            for key in self.keys_to_interp:
-                new_atom[key] = self.atom_buffer[key] + \
-                    (atom[key] - self.atom_buffer[key]) * progress
-            output.append(new_atom)
-
-            new_atom_datetime = new_atom_datetime + self.timeunit
-        self.atom_buffer = atom
-
-    @staticmethod
-    def __timedelta_from_interval(interval: str) -&gt; timedelta:
-        &#39;&#39;&#39;
-        Returns the unit timedelta given the interval.
-
-        Parameters:
-            interval : str
-                The interval to use to calculate the number of datetimes between the two give atoms&#39;.
-                Could be &#34;seconds&#34;, &#34;minutes&#34;, &#34;hours&#34;, &#34;days&#34;.
-        Returns:
-            datetime.timedelta
-        Raises:
-            ValueError if the interval is not supported
-        &#39;&#39;&#39;
-        value = TIMEDELTA_DICT.get(interval, None)
-        if(value == None):
-            raise ValueError(&#34;Interval {} is not supported&#34;.format(interval))
-        return value</code></pre>
+    def _create_atoms(self, B: dict) -&gt; Sequence[dict]:
+        raise NotImplementedError()</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="otri.filtering.filter.Filter" href="../filter.html#otri.filtering.filter.Filter">Filter</a></li>
 </ul>
-<h3>Methods</h3>
-<dl>
-<dt id="otri.filtering.filters.interpolation_filter.InterpolationFilter.execute"><code class="name flex">
-<span>def <span class="ident">execute</span></span>(<span>self)</span>
-</code></dt>
-<dd>
-<div class="desc"><p>Waits for two atoms and interpolates the given dictionary values.</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def execute(self):
-    &#39;&#39;&#39;
-    Waits for two atoms and interpolates the given dictionary values.
-    &#39;&#39;&#39;
-    if self.__output.is_closed():
-        return
-
-    if self.__input_iter.has_next():
-        atom = next(self.__input_iter)
-        if(self.atom_buffer == None):
-            # Do nothing, just save the atom for the next
-            self.atom_buffer = atom
-        else:
-            self.__create_missing_atoms(atom, self.__output)
-    elif(self.__input.is_closed()):
-        # Empty the atom_buffer (should contain one atom)
-        if(self.atom_buffer != None):
-            self.__output.append(self.atom_buffer)
-            self.atom_buffer = None
-        self.__output.close()</code></pre>
-</details>
-</dd>
-<dt id="otri.filtering.filters.interpolation_filter.InterpolationFilter.setup"><code class="name flex">
-<span>def <span class="ident">setup</span></span>(<span>self, inputs: Sequence[<a title="otri.filtering.stream.Stream" href="../stream.html#otri.filtering.stream.Stream">Stream</a>], outputs: Sequence[<a title="otri.filtering.stream.Stream" href="../stream.html#otri.filtering.stream.Stream">Stream</a>], state: Mapping[str, Any])</span>
-</code></dt>
-<dd>
-<div class="desc"><p>Used to save references to streams and reset variables.
-Called once before the start of the execution in FilterNet.</p>
-<h2 id="parameters">Parameters</h2>
-<p>inputs, outputs : Sequence[Stream]
-Ordered sequence containing the required input/output streams gained from the FilterNet.
-state : Mapping[str, Any]
-Dictionary containing states to output.</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def setup(self, inputs: Sequence[Stream], outputs: Sequence[Stream], state: Mapping[str, Any]):
-    &#39;&#39;&#39;
-    Used to save references to streams and reset variables.
-    Called once before the start of the execution in FilterNet.
-
-    Parameters:
-        inputs, outputs : Sequence[Stream]
-            Ordered sequence containing the required input/output streams gained from the FilterNet.
-        state : Mapping[str, Any]
-            Dictionary containing states to output.
-    &#39;&#39;&#39;
-    self.__input = inputs[0]
-    self.__input_iter = iter(inputs[0])
-    self.__output = outputs[0]</code></pre>
-</details>
-</dd>
-</dl>
+<h3>Subclasses</h3>
+<ul class="hlist">
+<li><a title="otri.filtering.filters.interpolation_filter.IntradayInterpolationFilter" href="#otri.filtering.filters.interpolation_filter.IntradayInterpolationFilter">IntradayInterpolationFilter</a></li>
+</ul>
 <h3>Inherited members</h3>
 <ul class="hlist">
 <li><code><b><a title="otri.filtering.filter.Filter" href="../filter.html#otri.filtering.filter.Filter">Filter</a></b></code>:
 <ul class="hlist">
-<li><code><a title="otri.filtering.filter.Filter.get_inputs" href="../filter.html#otri.filtering.filter.Filter.get_inputs">get_inputs</a></code></li>
-<li><code><a title="otri.filtering.filter.Filter.get_outputs" href="../filter.html#otri.filtering.filter.Filter.get_outputs">get_outputs</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.execute" href="../filter.html#otri.filtering.filter.Filter.execute">execute</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.get_input_names" href="../filter.html#otri.filtering.filter.Filter.get_input_names">get_input_names</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.get_output_names" href="../filter.html#otri.filtering.filter.Filter.get_output_names">get_output_names</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.setup" href="../filter.html#otri.filtering.filter.Filter.setup">setup</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+<dt id="otri.filtering.filters.interpolation_filter.IntradayInterpolationFilter"><code class="flex name class">
+<span>class <span class="ident">IntradayInterpolationFilter</span></span>
+<span>(</span><span>inputs: str, outputs: str, keys_to_interp: Collection[str], target_gap_seconds: int = 60, working_hours: tuple = (datetime.time(8, 0), datetime.time(20, 0)))</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Interpolates value between two stream atoms if their time difference is greater than a given maximum interval.
+The resulting atoms will have given values interpolated.</p>
+<h2 id="inputs">Inputs</h2>
+<p>Oredered by datetime atoms.</p>
+<h2 id="outputs">Outputs</h2>
+<p>Atoms interpolated at the desired frequency.</p>
+<h2 id="parameters">Parameters</h2>
+<p>inputs : str</p>
+<pre><code>Input stream name.
+</code></pre>
+<p>outputs : str</p>
+<pre><code>Output stream name.
+</code></pre>
+<p>keys_to_interp : Collection[str]</p>
+<pre><code>Collection of keys to update when calculating interpolation. Will be the only keys of the atoms (with datetime too).
+</code></pre>
+<p>target_gap_seconds : str</p>
+<pre><code>The target gap between atoms in seconds.
+</code></pre>
+<p>working_hours : tuple(start, end)</p>
+<pre><code>Tuple containing datetime.time for start hour minutes and seconds and end time. Values will be calculated inside these working hours only.
+The start time must be earlier than end time by at least one target_gap_seconds seconds
+</code></pre></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class IntradayInterpolationFilter(InterpolationFilter):
+    &#39;&#39;&#39;
+    Interpolates value between two stream atoms if their time difference is greater than a given maximum interval.
+    The resulting atoms will have given values interpolated.\n
+
+    Inputs:\n
+        Oredered by datetime atoms.\n
+    Outputs:\n
+        Atoms interpolated at the desired frequency.\n
+    &#39;&#39;&#39;
+
+    def __init__(self, inputs: str, outputs: str, keys_to_interp: Collection[str], target_gap_seconds: int = 60, working_hours: tuple = (time(hour=8), time(hour=20))):
+        &#39;&#39;&#39;
+        Parameters:\n
+            inputs : str\n
+                Input stream name.\n
+            outputs : str\n
+                Output stream name.\n
+            keys_to_interp : Collection[str]\n
+                Collection of keys to update when calculating interpolation. Will be the only keys of the atoms (with datetime too).\n
+            target_gap_seconds : str\n
+                The target gap between atoms in seconds.\n
+            working_hours : tuple(start, end)\n
+                Tuple containing datetime.time for start hour minutes and seconds and end time. Values will be calculated inside these working hours only.
+                The start time must be earlier than end time by at least one target_gap_seconds seconds\n
+        &#39;&#39;&#39;
+        super().__init__(
+            inputs=inputs,
+            outputs=outputs,
+            keys_to_interp=keys_to_interp
+        )
+        self.__gap_datetime = timedelta(seconds=target_gap_seconds)
+        self.__working_hours = working_hours
+        # Iterates through time of the day and resets on a new day
+        self.__instant_iterator = working_hours[0]
+
+    def _create_atoms(self, B: dict) -&gt; Any:
+        &#39;&#39;&#39;
+        Pushes into the output stream the current self.atom_buffer and all the interpolated atoms between that and the give atom.\n
+        &#39;&#39;&#39;
+        A_datetime = th.str_to_datetime(self.atom_buffer[&#39;datetime&#39;])
+        B_datetime = th.str_to_datetime(B[&#39;datetime&#39;])
+        A_epoch = th.datetime_to_epoch(A_datetime)
+        B_epoch = th.datetime_to_epoch(B_datetime)
+
+        interp_instants = []
+
+        # Interpolate from the starting hour for the first atom
+        if not hasattr(self, &#34;cur_day&#34;):
+            self.cur_day = A_datetime.date()
+            self.__instant_iterator = self.__working_hours[0]
+
+        while(self.__instant_iterator &lt;= th.datetime_to_time(A_datetime) and self.__instant_iterator &lt;= self.__working_hours[1]):
+            interp_instants.append(th.datetime_to_epoch(datetime.combine(A_datetime.date(), self.__instant_iterator)))
+            self.__instant_iterator = th.sum_time(self.__instant_iterator, self.__gap_datetime)
+        
+        # Interpolate between the two atoms
+        while(self.cur_day &lt; B_datetime.date()):
+            while(self.__instant_iterator &lt;= self.__working_hours[1]):
+                interp_instants.append(th.datetime_to_epoch(datetime.combine(self.cur_day, self.__instant_iterator)))
+                self.__instant_iterator = th.sum_time(self.__instant_iterator, self.__gap_datetime)
+            self.cur_day += timedelta(days=1)
+            self.__instant_iterator = self.__working_hours[0]
+
+        # Reached the B day
+        while(self.__instant_iterator &lt;= th.datetime_to_time(B_datetime) and self.__instant_iterator &lt;= self.__working_hours[1]):
+            interp_instants.append(th.datetime_to_epoch(datetime.combine(self.cur_day, self.__instant_iterator)))
+            self.__instant_iterator = th.sum_time(self.__instant_iterator, self.__gap_datetime)
+            
+        output_atoms = []
+        interp_values = {}
+        for key in self.keys_to_interp:
+            interp_values[key] = interp(
+                x = interp_instants,
+                xp = [A_epoch, B_epoch],
+                fp = [float(self.atom_buffer[key]), float(B[key])]
+            )
+        
+        for i in range(len(interp_instants)):
+            atom = {}
+            atom[&#39;datetime&#39;] = th.datetime_to_str(datetime.utcfromtimestamp(interp_instants[i]))
+            for key in self.keys_to_interp:
+                atom[key] = interp_values[key][i]
+            output_atoms.append(atom)
+
+        return output_atoms</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="otri.filtering.filters.interpolation_filter.InterpolationFilter" href="#otri.filtering.filters.interpolation_filter.InterpolationFilter">InterpolationFilter</a></li>
+<li><a title="otri.filtering.filter.Filter" href="../filter.html#otri.filtering.filter.Filter">Filter</a></li>
+</ul>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="otri.filtering.filters.interpolation_filter.InterpolationFilter" href="#otri.filtering.filters.interpolation_filter.InterpolationFilter">InterpolationFilter</a></b></code>:
+<ul class="hlist">
+<li><code><a title="otri.filtering.filters.interpolation_filter.InterpolationFilter.execute" href="../filter.html#otri.filtering.filter.Filter.execute">execute</a></code></li>
+<li><code><a title="otri.filtering.filters.interpolation_filter.InterpolationFilter.get_input_names" href="../filter.html#otri.filtering.filter.Filter.get_input_names">get_input_names</a></code></li>
+<li><code><a title="otri.filtering.filters.interpolation_filter.InterpolationFilter.get_output_names" href="../filter.html#otri.filtering.filter.Filter.get_output_names">get_output_names</a></code></li>
+<li><code><a title="otri.filtering.filters.interpolation_filter.InterpolationFilter.setup" href="../filter.html#otri.filtering.filter.Filter.setup">setup</a></code></li>
 </ul>
 </li>
 </ul>
@@ -401,10 +447,9 @@ Dictionary containing states to output.</p></div>
 <ul>
 <li>
 <h4><code><a title="otri.filtering.filters.interpolation_filter.InterpolationFilter" href="#otri.filtering.filters.interpolation_filter.InterpolationFilter">InterpolationFilter</a></code></h4>
-<ul class="">
-<li><code><a title="otri.filtering.filters.interpolation_filter.InterpolationFilter.execute" href="#otri.filtering.filters.interpolation_filter.InterpolationFilter.execute">execute</a></code></li>
-<li><code><a title="otri.filtering.filters.interpolation_filter.InterpolationFilter.setup" href="#otri.filtering.filters.interpolation_filter.InterpolationFilter.setup">setup</a></code></li>
-</ul>
+</li>
+<li>
+<h4><code><a title="otri.filtering.filters.interpolation_filter.IntradayInterpolationFilter" href="#otri.filtering.filters.interpolation_filter.IntradayInterpolationFilter">IntradayInterpolationFilter</a></code></h4>
 </li>
 </ul>
 </li>

--- a/doc/otri/filtering/filters/interpolation_filter.html
+++ b/doc/otri/filtering/filters/interpolation_filter.html
@@ -79,15 +79,6 @@ class InterpolationFilter(Filter):
             for atom in output_atoms:
                 self._push_data(atom)
 
-    def _on_inputs_closed(self):
-        &#39;&#39;&#39;
-        Pushes out the atom in the buffer and closes the outputs
-        &#39;&#39;&#39;
-        if(self.atom_buffer != None):
-            self._push_data(self.atom_buffer)
-            self.atom_buffer = None
-        super()._on_inputs_closed()
-
     def _create_atoms(self, B: dict) -&gt; Sequence[dict]:
         raise NotImplementedError()
 
@@ -260,15 +251,6 @@ Tuple containing datetime for start hour minutes and seconds and end time. Value
             output_atoms = self._create_atoms(data)
             for atom in output_atoms:
                 self._push_data(atom)
-
-    def _on_inputs_closed(self):
-        &#39;&#39;&#39;
-        Pushes out the atom in the buffer and closes the outputs
-        &#39;&#39;&#39;
-        if(self.atom_buffer != None):
-            self._push_data(self.atom_buffer)
-            self.atom_buffer = None
-        super()._on_inputs_closed()
 
     def _create_atoms(self, B: dict) -&gt; Sequence[dict]:
         raise NotImplementedError()</code></pre>

--- a/doc/otri/filtering/filters/math_filter.html
+++ b/doc/otri/filtering/filters/math_filter.html
@@ -33,9 +33,10 @@ from typing import Callable
 class MathFilter(Filter):
     &#39;&#39;&#39;
     Performs a give operation on keys of an item.
-    Input:
+
+    Inputs:
         Single stream.
-    Output:
+    Outputs:
         Single stream.
     &#39;&#39;&#39;
 
@@ -56,36 +57,13 @@ class MathFilter(Filter):
             output_count=1)
         self.__keys_operations = keys_operations
 
-    def setup(self, inputs: Sequence[Stream], outputs: Sequence[Stream], state: Mapping[str, Any]):
+    def _on_data(self, data, index):
         &#39;&#39;&#39;
-        Used to save references to streams and reset variables.
-        Called once before the start of the execution in FilterNet.
-
-        Parameters:
-            inputs, outputs : Sequence[Stream]
-                Ordered sequence containing the required input/output streams gained from the FilterNet.
-            state : Mapping[str, Any]
-                Dictionary containing states to output.
+        Applies the given math to those values that match the given keys in the atom.
         &#39;&#39;&#39;
-        self.__input = inputs[0]
-        self.__input_iter = iter(inputs[0])
-        self.__output = outputs[0]
-
-    def execute(self):
-        &#39;&#39;&#39;
-        Performs given operations on keys of the item.
-        &#39;&#39;&#39;
-        if(self.__output.is_closed()):
-            return
-
-        if( self.__input_iter.has_next()):
-            atom = next(self.__input_iter)
-            for key in self.__keys_operations.keys():
-                atom[key] = self.__keys_operations[key](atom[key])
-            self.__output.append(atom)
-
-        elif(self.__input.is_closed()):
-            self.__output.close()</code></pre>
+        for key in self.__keys_operations.keys():
+            data[key] = self.__keys_operations[key](data[key])
+        self._push_data(data)</code></pre>
 </details>
 </section>
 <section>
@@ -103,9 +81,9 @@ class MathFilter(Filter):
 </code></dt>
 <dd>
 <div class="desc"><p>Performs a give operation on keys of an item.</p>
-<h2 id="input">Input</h2>
+<h2 id="inputs">Inputs</h2>
 <p>Single stream.</p>
-<h2 id="output">Output</h2>
+<h2 id="outputs">Outputs</h2>
 <p>Single stream.</p>
 <h2 id="parameters">Parameters</h2>
 <p>input : str
@@ -121,9 +99,10 @@ Collection of keys whom values will be summed for the given constant.</p></div>
 <pre><code class="python">class MathFilter(Filter):
     &#39;&#39;&#39;
     Performs a give operation on keys of an item.
-    Input:
+
+    Inputs:
         Single stream.
-    Output:
+    Outputs:
         Single stream.
     &#39;&#39;&#39;
 
@@ -144,107 +123,26 @@ Collection of keys whom values will be summed for the given constant.</p></div>
             output_count=1)
         self.__keys_operations = keys_operations
 
-    def setup(self, inputs: Sequence[Stream], outputs: Sequence[Stream], state: Mapping[str, Any]):
+    def _on_data(self, data, index):
         &#39;&#39;&#39;
-        Used to save references to streams and reset variables.
-        Called once before the start of the execution in FilterNet.
-
-        Parameters:
-            inputs, outputs : Sequence[Stream]
-                Ordered sequence containing the required input/output streams gained from the FilterNet.
-            state : Mapping[str, Any]
-                Dictionary containing states to output.
+        Applies the given math to those values that match the given keys in the atom.
         &#39;&#39;&#39;
-        self.__input = inputs[0]
-        self.__input_iter = iter(inputs[0])
-        self.__output = outputs[0]
-
-    def execute(self):
-        &#39;&#39;&#39;
-        Performs given operations on keys of the item.
-        &#39;&#39;&#39;
-        if(self.__output.is_closed()):
-            return
-
-        if( self.__input_iter.has_next()):
-            atom = next(self.__input_iter)
-            for key in self.__keys_operations.keys():
-                atom[key] = self.__keys_operations[key](atom[key])
-            self.__output.append(atom)
-
-        elif(self.__input.is_closed()):
-            self.__output.close()</code></pre>
+        for key in self.__keys_operations.keys():
+            data[key] = self.__keys_operations[key](data[key])
+        self._push_data(data)</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="otri.filtering.filter.Filter" href="../filter.html#otri.filtering.filter.Filter">Filter</a></li>
 </ul>
-<h3>Methods</h3>
-<dl>
-<dt id="otri.filtering.filters.math_filter.MathFilter.execute"><code class="name flex">
-<span>def <span class="ident">execute</span></span>(<span>self)</span>
-</code></dt>
-<dd>
-<div class="desc"><p>Performs given operations on keys of the item.</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def execute(self):
-    &#39;&#39;&#39;
-    Performs given operations on keys of the item.
-    &#39;&#39;&#39;
-    if(self.__output.is_closed()):
-        return
-
-    if( self.__input_iter.has_next()):
-        atom = next(self.__input_iter)
-        for key in self.__keys_operations.keys():
-            atom[key] = self.__keys_operations[key](atom[key])
-        self.__output.append(atom)
-
-    elif(self.__input.is_closed()):
-        self.__output.close()</code></pre>
-</details>
-</dd>
-<dt id="otri.filtering.filters.math_filter.MathFilter.setup"><code class="name flex">
-<span>def <span class="ident">setup</span></span>(<span>self, inputs: Sequence[<a title="otri.filtering.stream.Stream" href="../stream.html#otri.filtering.stream.Stream">Stream</a>], outputs: Sequence[<a title="otri.filtering.stream.Stream" href="../stream.html#otri.filtering.stream.Stream">Stream</a>], state: Mapping[str, Any])</span>
-</code></dt>
-<dd>
-<div class="desc"><p>Used to save references to streams and reset variables.
-Called once before the start of the execution in FilterNet.</p>
-<h2 id="parameters">Parameters</h2>
-<p>inputs, outputs : Sequence[Stream]
-Ordered sequence containing the required input/output streams gained from the FilterNet.
-state : Mapping[str, Any]
-Dictionary containing states to output.</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def setup(self, inputs: Sequence[Stream], outputs: Sequence[Stream], state: Mapping[str, Any]):
-    &#39;&#39;&#39;
-    Used to save references to streams and reset variables.
-    Called once before the start of the execution in FilterNet.
-
-    Parameters:
-        inputs, outputs : Sequence[Stream]
-            Ordered sequence containing the required input/output streams gained from the FilterNet.
-        state : Mapping[str, Any]
-            Dictionary containing states to output.
-    &#39;&#39;&#39;
-    self.__input = inputs[0]
-    self.__input_iter = iter(inputs[0])
-    self.__output = outputs[0]</code></pre>
-</details>
-</dd>
-</dl>
 <h3>Inherited members</h3>
 <ul class="hlist">
 <li><code><b><a title="otri.filtering.filter.Filter" href="../filter.html#otri.filtering.filter.Filter">Filter</a></b></code>:
 <ul class="hlist">
-<li><code><a title="otri.filtering.filter.Filter.get_inputs" href="../filter.html#otri.filtering.filter.Filter.get_inputs">get_inputs</a></code></li>
-<li><code><a title="otri.filtering.filter.Filter.get_outputs" href="../filter.html#otri.filtering.filter.Filter.get_outputs">get_outputs</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.execute" href="../filter.html#otri.filtering.filter.Filter.execute">execute</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.get_input_names" href="../filter.html#otri.filtering.filter.Filter.get_input_names">get_input_names</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.get_output_names" href="../filter.html#otri.filtering.filter.Filter.get_output_names">get_output_names</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.setup" href="../filter.html#otri.filtering.filter.Filter.setup">setup</a></code></li>
 </ul>
 </li>
 </ul>
@@ -267,10 +165,6 @@ Dictionary containing states to output.</p></div>
 <ul>
 <li>
 <h4><code><a title="otri.filtering.filters.math_filter.MathFilter" href="#otri.filtering.filters.math_filter.MathFilter">MathFilter</a></code></h4>
-<ul class="">
-<li><code><a title="otri.filtering.filters.math_filter.MathFilter.execute" href="#otri.filtering.filters.math_filter.MathFilter.execute">execute</a></code></li>
-<li><code><a title="otri.filtering.filters.math_filter.MathFilter.setup" href="#otri.filtering.filters.math_filter.MathFilter.setup">setup</a></code></li>
-</ul>
 </li>
 </ul>
 </li>

--- a/doc/otri/filtering/filters/merge_filter.html
+++ b/doc/otri/filtering/filters/merge_filter.html
@@ -32,10 +32,10 @@
 class SequentialMergeFilter(Filter):
     &#39;&#39;&#39;
     Sequentially merges elements from multiple streams into one single output.
-    
-    Input:
+
+    Inputs:
         Multiple streams.
-    Output:
+    Outputs:
         A single stream containing data read sequentially (all of stream 1, then all of stream 2 and so on).
     &#39;&#39;&#39;
 
@@ -53,38 +53,18 @@ class SequentialMergeFilter(Filter):
             input_count=len(inputs),
             output_count=1)
 
-    def setup(self, inputs: Sequence[Stream], outputs: Sequence[Stream], state: Mapping[str, Any]):
+    def _on_data(self, data, index):
         &#39;&#39;&#39;
-        Used to save references to streams and reset variables.
-        Called once before the start of the execution in FilterNet.
+        Places the passed atom in the only output.
+        &#39;&#39;&#39;
+        self._push_data(data)
 
-        Parameters:
-            inputs, outputs : Sequence[Stream]
-                Ordered sequence containing the required input/output streams gained from the FilterNet.
-            state : Mapping[str, Any]
-                Dictionary containing states to output.
+    def _input_check_order(self) -&gt; Sequence:
         &#39;&#39;&#39;
-        self.__inputs = inputs
-        self.__output = outputs[0]
-
-    def execute(self):
+        Defines the order for the inputs to be checked.
+        We choose it to be sequential.
         &#39;&#39;&#39;
-        Pops elements from the input streams sequentially (all of stream 0 then all of stream 1 and so on) and places them into the single output stream.
-        &#39;&#39;&#39;
-        if(self.__output.is_closed()):
-            return
-        # Extracts input data sequentially from each input filter
-        for input_str in self.__inputs:
-            if iter(input_str).has_next():
-                self.__output.append(next(iter(input_str)))
-                return
-        # Checks if there is anymore data
-        for input_str in self.__inputs:
-            if not input_str.is_closed():
-                return
-            
-        # If we get here it means that all of the input streams are closed, hence we define the output as closed
-        self.__output.close()</code></pre>
+        return range(0, len(self.get_input_names()))</code></pre>
 </details>
 </section>
 <section>
@@ -102,9 +82,9 @@ class SequentialMergeFilter(Filter):
 </code></dt>
 <dd>
 <div class="desc"><p>Sequentially merges elements from multiple streams into one single output.</p>
-<h2 id="input">Input</h2>
+<h2 id="inputs">Inputs</h2>
 <p>Multiple streams.</p>
-<h2 id="output">Output</h2>
+<h2 id="outputs">Outputs</h2>
 <p>A single stream containing data read sequentially (all of stream 1, then all of stream 2 and so on).</p>
 <h2 id="parameters">Parameters</h2>
 <p>input : Sequence[str]
@@ -118,10 +98,10 @@ Name for output stream.</p></div>
 <pre><code class="python">class SequentialMergeFilter(Filter):
     &#39;&#39;&#39;
     Sequentially merges elements from multiple streams into one single output.
-    
-    Input:
+
+    Inputs:
         Multiple streams.
-    Output:
+    Outputs:
         A single stream containing data read sequentially (all of stream 1, then all of stream 2 and so on).
     &#39;&#39;&#39;
 
@@ -139,111 +119,31 @@ Name for output stream.</p></div>
             input_count=len(inputs),
             output_count=1)
 
-    def setup(self, inputs: Sequence[Stream], outputs: Sequence[Stream], state: Mapping[str, Any]):
+    def _on_data(self, data, index):
         &#39;&#39;&#39;
-        Used to save references to streams and reset variables.
-        Called once before the start of the execution in FilterNet.
+        Places the passed atom in the only output.
+        &#39;&#39;&#39;
+        self._push_data(data)
 
-        Parameters:
-            inputs, outputs : Sequence[Stream]
-                Ordered sequence containing the required input/output streams gained from the FilterNet.
-            state : Mapping[str, Any]
-                Dictionary containing states to output.
+    def _input_check_order(self) -&gt; Sequence:
         &#39;&#39;&#39;
-        self.__inputs = inputs
-        self.__output = outputs[0]
-
-    def execute(self):
+        Defines the order for the inputs to be checked.
+        We choose it to be sequential.
         &#39;&#39;&#39;
-        Pops elements from the input streams sequentially (all of stream 0 then all of stream 1 and so on) and places them into the single output stream.
-        &#39;&#39;&#39;
-        if(self.__output.is_closed()):
-            return
-        # Extracts input data sequentially from each input filter
-        for input_str in self.__inputs:
-            if iter(input_str).has_next():
-                self.__output.append(next(iter(input_str)))
-                return
-        # Checks if there is anymore data
-        for input_str in self.__inputs:
-            if not input_str.is_closed():
-                return
-            
-        # If we get here it means that all of the input streams are closed, hence we define the output as closed
-        self.__output.close()</code></pre>
+        return range(0, len(self.get_input_names()))</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="otri.filtering.filter.Filter" href="../filter.html#otri.filtering.filter.Filter">Filter</a></li>
 </ul>
-<h3>Methods</h3>
-<dl>
-<dt id="otri.filtering.filters.merge_filter.SequentialMergeFilter.execute"><code class="name flex">
-<span>def <span class="ident">execute</span></span>(<span>self)</span>
-</code></dt>
-<dd>
-<div class="desc"><p>Pops elements from the input streams sequentially (all of stream 0 then all of stream 1 and so on) and places them into the single output stream.</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def execute(self):
-    &#39;&#39;&#39;
-    Pops elements from the input streams sequentially (all of stream 0 then all of stream 1 and so on) and places them into the single output stream.
-    &#39;&#39;&#39;
-    if(self.__output.is_closed()):
-        return
-    # Extracts input data sequentially from each input filter
-    for input_str in self.__inputs:
-        if iter(input_str).has_next():
-            self.__output.append(next(iter(input_str)))
-            return
-    # Checks if there is anymore data
-    for input_str in self.__inputs:
-        if not input_str.is_closed():
-            return
-        
-    # If we get here it means that all of the input streams are closed, hence we define the output as closed
-    self.__output.close()</code></pre>
-</details>
-</dd>
-<dt id="otri.filtering.filters.merge_filter.SequentialMergeFilter.setup"><code class="name flex">
-<span>def <span class="ident">setup</span></span>(<span>self, inputs: Sequence[<a title="otri.filtering.stream.Stream" href="../stream.html#otri.filtering.stream.Stream">Stream</a>], outputs: Sequence[<a title="otri.filtering.stream.Stream" href="../stream.html#otri.filtering.stream.Stream">Stream</a>], state: Mapping[str, Any])</span>
-</code></dt>
-<dd>
-<div class="desc"><p>Used to save references to streams and reset variables.
-Called once before the start of the execution in FilterNet.</p>
-<h2 id="parameters">Parameters</h2>
-<p>inputs, outputs : Sequence[Stream]
-Ordered sequence containing the required input/output streams gained from the FilterNet.
-state : Mapping[str, Any]
-Dictionary containing states to output.</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def setup(self, inputs: Sequence[Stream], outputs: Sequence[Stream], state: Mapping[str, Any]):
-    &#39;&#39;&#39;
-    Used to save references to streams and reset variables.
-    Called once before the start of the execution in FilterNet.
-
-    Parameters:
-        inputs, outputs : Sequence[Stream]
-            Ordered sequence containing the required input/output streams gained from the FilterNet.
-        state : Mapping[str, Any]
-            Dictionary containing states to output.
-    &#39;&#39;&#39;
-    self.__inputs = inputs
-    self.__output = outputs[0]</code></pre>
-</details>
-</dd>
-</dl>
 <h3>Inherited members</h3>
 <ul class="hlist">
 <li><code><b><a title="otri.filtering.filter.Filter" href="../filter.html#otri.filtering.filter.Filter">Filter</a></b></code>:
 <ul class="hlist">
-<li><code><a title="otri.filtering.filter.Filter.get_inputs" href="../filter.html#otri.filtering.filter.Filter.get_inputs">get_inputs</a></code></li>
-<li><code><a title="otri.filtering.filter.Filter.get_outputs" href="../filter.html#otri.filtering.filter.Filter.get_outputs">get_outputs</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.execute" href="../filter.html#otri.filtering.filter.Filter.execute">execute</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.get_input_names" href="../filter.html#otri.filtering.filter.Filter.get_input_names">get_input_names</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.get_output_names" href="../filter.html#otri.filtering.filter.Filter.get_output_names">get_output_names</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.setup" href="../filter.html#otri.filtering.filter.Filter.setup">setup</a></code></li>
 </ul>
 </li>
 </ul>
@@ -266,10 +166,6 @@ Dictionary containing states to output.</p></div>
 <ul>
 <li>
 <h4><code><a title="otri.filtering.filters.merge_filter.SequentialMergeFilter" href="#otri.filtering.filters.merge_filter.SequentialMergeFilter">SequentialMergeFilter</a></code></h4>
-<ul class="">
-<li><code><a title="otri.filtering.filters.merge_filter.SequentialMergeFilter.execute" href="#otri.filtering.filters.merge_filter.SequentialMergeFilter.execute">execute</a></code></li>
-<li><code><a title="otri.filtering.filters.merge_filter.SequentialMergeFilter.setup" href="#otri.filtering.filters.merge_filter.SequentialMergeFilter.setup">setup</a></code></li>
-</ul>
 </li>
 </ul>
 </li>

--- a/doc/otri/filtering/filters/nuplicator_filter.html
+++ b/doc/otri/filtering/filters/nuplicator_filter.html
@@ -34,7 +34,7 @@ class NUplicatorFilter(Filter):
     &#39;&#39;&#39;
     N-uplicates the input stream. Placing a copy of the input in each output filter.
 
-    Input: 
+    Inputs: 
         Single stream.
     Outputs:
         Any number of streams.
@@ -58,39 +58,12 @@ class NUplicatorFilter(Filter):
         )
         self.__copy = copy.deepcopy if deep_copy else copy.copy
 
-    def setup(self, inputs : Sequence[Stream], outputs : Sequence[Stream], state: Mapping[str, Any]):
+    def _on_data(self, data, index):
         &#39;&#39;&#39;
-        Used to save references to streams and reset variables.
-        Called once before the start of the execution in FilterNet.
-
-        Parameters:
-            inputs, outputs : Sequence[Stream]
-                Ordered sequence containing the required input/output streams gained from the FilterNet.
-            state : Mapping[str, Any]
-                Dictionary containing states to output.
+        Copies reference or deep copies atoms in multiple outputs.
         &#39;&#39;&#39;
-        self.__input = inputs[0]
-        self.__input_iter = iter(inputs[0])
-        self.__outputs = outputs
-
-    def execute(self):
-        &#39;&#39;&#39;
-        Method called when a single step in the filtering must be taken.
-        If the input stream has another item, copy it to all output streams.
-        If the input stream has no other item and got closed, then we also close
-        the output streams.
-        &#39;&#39;&#39;
-        if self.__outputs[0].is_closed():
-            return
-        if self.__input_iter.has_next():
-            item = next(self.__input_iter)
-            for output in self.__outputs:
-                output.append(self.__copy(item))
-        elif self.__input.is_closed():
-            # Closed input -&gt; Close outputs
-            for output in self.__outputs:
-                
-                output.close()</code></pre>
+        for i in range(len(self.get_output_names())):
+            self._push_data(self.__copy(data), index = i)</code></pre>
 </details>
 </section>
 <section>
@@ -108,7 +81,7 @@ class NUplicatorFilter(Filter):
 </code></dt>
 <dd>
 <div class="desc"><p>N-uplicates the input stream. Placing a copy of the input in each output filter.</p>
-<p>Input:
+<p>Inputs:
 Single stream.</p>
 <h2 id="outputs">Outputs</h2>
 <p>Any number of streams.</p>
@@ -127,7 +100,7 @@ Whether the items from the input stream should be deep copies or shallow copies<
     &#39;&#39;&#39;
     N-uplicates the input stream. Placing a copy of the input in each output filter.
 
-    Input: 
+    Inputs: 
         Single stream.
     Outputs:
         Any number of streams.
@@ -151,116 +124,25 @@ Whether the items from the input stream should be deep copies or shallow copies<
         )
         self.__copy = copy.deepcopy if deep_copy else copy.copy
 
-    def setup(self, inputs : Sequence[Stream], outputs : Sequence[Stream], state: Mapping[str, Any]):
+    def _on_data(self, data, index):
         &#39;&#39;&#39;
-        Used to save references to streams and reset variables.
-        Called once before the start of the execution in FilterNet.
-
-        Parameters:
-            inputs, outputs : Sequence[Stream]
-                Ordered sequence containing the required input/output streams gained from the FilterNet.
-            state : Mapping[str, Any]
-                Dictionary containing states to output.
+        Copies reference or deep copies atoms in multiple outputs.
         &#39;&#39;&#39;
-        self.__input = inputs[0]
-        self.__input_iter = iter(inputs[0])
-        self.__outputs = outputs
-
-    def execute(self):
-        &#39;&#39;&#39;
-        Method called when a single step in the filtering must be taken.
-        If the input stream has another item, copy it to all output streams.
-        If the input stream has no other item and got closed, then we also close
-        the output streams.
-        &#39;&#39;&#39;
-        if self.__outputs[0].is_closed():
-            return
-        if self.__input_iter.has_next():
-            item = next(self.__input_iter)
-            for output in self.__outputs:
-                output.append(self.__copy(item))
-        elif self.__input.is_closed():
-            # Closed input -&gt; Close outputs
-            for output in self.__outputs:
-                
-                output.close()</code></pre>
+        for i in range(len(self.get_output_names())):
+            self._push_data(self.__copy(data), index = i)</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">
 <li><a title="otri.filtering.filter.Filter" href="../filter.html#otri.filtering.filter.Filter">Filter</a></li>
 </ul>
-<h3>Methods</h3>
-<dl>
-<dt id="otri.filtering.filters.nuplicator_filter.NUplicatorFilter.execute"><code class="name flex">
-<span>def <span class="ident">execute</span></span>(<span>self)</span>
-</code></dt>
-<dd>
-<div class="desc"><p>Method called when a single step in the filtering must be taken.
-If the input stream has another item, copy it to all output streams.
-If the input stream has no other item and got closed, then we also close
-the output streams.</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def execute(self):
-    &#39;&#39;&#39;
-    Method called when a single step in the filtering must be taken.
-    If the input stream has another item, copy it to all output streams.
-    If the input stream has no other item and got closed, then we also close
-    the output streams.
-    &#39;&#39;&#39;
-    if self.__outputs[0].is_closed():
-        return
-    if self.__input_iter.has_next():
-        item = next(self.__input_iter)
-        for output in self.__outputs:
-            output.append(self.__copy(item))
-    elif self.__input.is_closed():
-        # Closed input -&gt; Close outputs
-        for output in self.__outputs:
-            
-            output.close()</code></pre>
-</details>
-</dd>
-<dt id="otri.filtering.filters.nuplicator_filter.NUplicatorFilter.setup"><code class="name flex">
-<span>def <span class="ident">setup</span></span>(<span>self, inputs: Sequence[<a title="otri.filtering.stream.Stream" href="../stream.html#otri.filtering.stream.Stream">Stream</a>], outputs: Sequence[<a title="otri.filtering.stream.Stream" href="../stream.html#otri.filtering.stream.Stream">Stream</a>], state: Mapping[str, Any])</span>
-</code></dt>
-<dd>
-<div class="desc"><p>Used to save references to streams and reset variables.
-Called once before the start of the execution in FilterNet.</p>
-<h2 id="parameters">Parameters</h2>
-<p>inputs, outputs : Sequence[Stream]
-Ordered sequence containing the required input/output streams gained from the FilterNet.
-state : Mapping[str, Any]
-Dictionary containing states to output.</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def setup(self, inputs : Sequence[Stream], outputs : Sequence[Stream], state: Mapping[str, Any]):
-    &#39;&#39;&#39;
-    Used to save references to streams and reset variables.
-    Called once before the start of the execution in FilterNet.
-
-    Parameters:
-        inputs, outputs : Sequence[Stream]
-            Ordered sequence containing the required input/output streams gained from the FilterNet.
-        state : Mapping[str, Any]
-            Dictionary containing states to output.
-    &#39;&#39;&#39;
-    self.__input = inputs[0]
-    self.__input_iter = iter(inputs[0])
-    self.__outputs = outputs</code></pre>
-</details>
-</dd>
-</dl>
 <h3>Inherited members</h3>
 <ul class="hlist">
 <li><code><b><a title="otri.filtering.filter.Filter" href="../filter.html#otri.filtering.filter.Filter">Filter</a></b></code>:
 <ul class="hlist">
-<li><code><a title="otri.filtering.filter.Filter.get_inputs" href="../filter.html#otri.filtering.filter.Filter.get_inputs">get_inputs</a></code></li>
-<li><code><a title="otri.filtering.filter.Filter.get_outputs" href="../filter.html#otri.filtering.filter.Filter.get_outputs">get_outputs</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.execute" href="../filter.html#otri.filtering.filter.Filter.execute">execute</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.get_input_names" href="../filter.html#otri.filtering.filter.Filter.get_input_names">get_input_names</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.get_output_names" href="../filter.html#otri.filtering.filter.Filter.get_output_names">get_output_names</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.setup" href="../filter.html#otri.filtering.filter.Filter.setup">setup</a></code></li>
 </ul>
 </li>
 </ul>
@@ -283,10 +165,6 @@ Dictionary containing states to output.</p></div>
 <ul>
 <li>
 <h4><code><a title="otri.filtering.filters.nuplicator_filter.NUplicatorFilter" href="#otri.filtering.filters.nuplicator_filter.NUplicatorFilter">NUplicatorFilter</a></code></h4>
-<ul class="">
-<li><code><a title="otri.filtering.filters.nuplicator_filter.NUplicatorFilter.execute" href="#otri.filtering.filters.nuplicator_filter.NUplicatorFilter.execute">execute</a></code></li>
-<li><code><a title="otri.filtering.filters.nuplicator_filter.NUplicatorFilter.setup" href="#otri.filtering.filters.nuplicator_filter.NUplicatorFilter.setup">setup</a></code></li>
-</ul>
 </li>
 </ul>
 </li>

--- a/doc/otri/filtering/filters/phase_filter.html
+++ b/doc/otri/filtering/filters/phase_filter.html
@@ -34,9 +34,9 @@ class PhaseFilter(Filter):
     &#39;&#39;&#39;
     Applies an operation to the i atom&#39;s keys and i+c atom&#39;s keys.
 
-    Input:
-        Single stream ordered by datetime
-    Output:
+    Inputs:
+        Single stream ordered by datetime.
+    Outputs:
         Single stream containing n - c atoms, whose fields are the
         result of the given operation between the atoms at positions
         i and i+c in the input Stream. Such fields are the only fields
@@ -57,7 +57,7 @@ class PhaseFilter(Filter):
                 These keys should be in all of the atoms of the Stream, to allow a proper output
                 Stream. These will be the only keys in the output atoms.
             distance : int
-                Distance in number of atoms to calculate a[i] * a[i+c]
+                Distance in number of atoms to calculate a[i] * a[i+c].
         &#39;&#39;&#39;
         super().__init__(
             inputs=[inputs],
@@ -70,22 +70,7 @@ class PhaseFilter(Filter):
         self.__atoms_buffer = list()
         self.__counter = 0
 
-    def setup(self, inputs: Sequence[Stream], outputs: Sequence[Stream], state: Mapping[str, Any]):
-        &#39;&#39;&#39;
-        Used to save references to streams and reset variables.
-        Called once before the start of the execution in FilterNet.
-
-        Parameters:
-            inputs, outputs : Sequence[Stream]
-                Ordered sequence containing the required input/output streams gained from the FilterNet.
-            state : Mapping[str, Any]
-                Dictionary containing states to output.
-        &#39;&#39;&#39;
-        self.__input = inputs[0]
-        self.__input_iter = iter(inputs[0])
-        self.__output = outputs[0]
-
-    def execute(self):
+    def _on_data(self, data, index):
         &#39;&#39;&#39;
         Pops atoms from the input Stream and places them in an internal buffer.
         When the internal buffer reaches the size of the requested distance we
@@ -93,32 +78,27 @@ class PhaseFilter(Filter):
         in the `keys_to_change` init parameter. The last `distance` parameters
         are discarded.
         &#39;&#39;&#39;
-        if(self.__output.is_closed()):
-            return
-
-        if(self.__input_iter.has_next()):
-            if(len(self.__atoms_buffer) &lt; self.__counter + 1):
-                self.__atoms_buffer.append(next(self.__input_iter))
-            else:
-                atom_1 = self.__atoms_buffer[self.__counter]
-                atom_2 = next(self.__input_iter)
-                mul_atom = dict()
-                for k in self.__keys.keys():
-                    mul_atom[k] = self.__keys[k](atom_1[k], atom_2[k])
-                self.__atoms_buffer[self.__counter] = atom_2
-                self.__output.append(mul_atom)
-            self.__counter = (self.__counter + 1) % self.__distance
-        elif(self.__input.is_closed()):
-            self.__output.close()
+        if(len(self.__atoms_buffer) &lt; self.__counter + 1):
+            self.__atoms_buffer.append(data)
+        else:
+            atom_1 = self.__atoms_buffer[self.__counter]
+            atom_2 = data
+            mul_atom = dict()
+            for k in self.__keys.keys():
+                mul_atom[k] = self.__keys[k](atom_1[k], atom_2[k])
+            self.__atoms_buffer[self.__counter] = atom_2
+            self._push_data(mul_atom)
+        self.__counter = (self.__counter + 1) % self.__distance
 
 
 class PhaseMulFilter(PhaseFilter):
     &#39;&#39;&#39;
-    Multiplies i atom&#39;s given keys with i+c atom&#39;s keys
-    Input:
-        Single stream ordered by datetime
-    Output:
-        Single stream containing n - c atoms
+    Multiplies i atom&#39;s given keys with i+c atom&#39;s keys.
+
+    Inputs:
+        Single stream ordered by datetime.
+    Outputs:
+        Single stream containing n - c atoms.
     &#39;&#39;&#39;
 
     def __init__(self, inputs: str, outputs: str, keys_to_change: Collection[str], distance: int):
@@ -131,7 +111,7 @@ class PhaseMulFilter(PhaseFilter):
             keys_to_change : Collection[str]
                 Collection of keys whom values will be multiplied.
             distance : int
-                Distance in number of atoms to calculate a[i] * a[i+c]
+                Distance in number of atoms to calculate a[i] * a[i+c].
         &#39;&#39;&#39;
         super().__init__(
             inputs=inputs,
@@ -143,11 +123,12 @@ class PhaseMulFilter(PhaseFilter):
 
 class PhaseDeltaFilter(PhaseFilter):
     &#39;&#39;&#39;
-    Subtracts i atom&#39;s given keys with i+c atom&#39;s keys
-    Input:
-        Single stream ordered by datetime
-    Output:
-        Single stream containing n - c atoms
+    Subtracts i atom&#39;s given keys with i+c atom&#39;s keys.
+
+    Inputs:
+        Single stream ordered by datetime.
+    Outputs:
+        Single stream containing n - c atoms.
     &#39;&#39;&#39;
 
     def __init__(self, inputs: str, outputs: str, keys_to_change: Collection[str], distance: int):
@@ -160,7 +141,7 @@ class PhaseDeltaFilter(PhaseFilter):
             keys_to_change : Collection[str]
                 Collection of keys whom deltas will be calculated.
             distance : int
-                Distance in number of atoms for which to calculate a[i] - a[i+c]
+                Distance in number of atoms for which to calculate a[i] - a[i+c].
         &#39;&#39;&#39;
         super().__init__(
             inputs=inputs,
@@ -184,11 +165,11 @@ class PhaseDeltaFilter(PhaseFilter):
 <span>(</span><span>inputs: str, outputs: str, keys_to_change: Collection[str], distance: int)</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Subtracts i atom's given keys with i+c atom's keys</p>
-<h2 id="input">Input</h2>
-<p>Single stream ordered by datetime</p>
-<h2 id="output">Output</h2>
-<p>Single stream containing n - c atoms</p>
+<div class="desc"><p>Subtracts i atom's given keys with i+c atom's keys.</p>
+<h2 id="inputs">Inputs</h2>
+<p>Single stream ordered by datetime.</p>
+<h2 id="outputs">Outputs</h2>
+<p>Single stream containing n - c atoms.</p>
 <h2 id="parameters">Parameters</h2>
 <p>inputs : str
 Input stream name.
@@ -197,18 +178,19 @@ Output stream name.
 keys_to_change : Collection[str]
 Collection of keys whom deltas will be calculated.
 distance : int
-Distance in number of atoms for which to calculate a[i] - a[i+c]</p></div>
+Distance in number of atoms for which to calculate a[i] - a[i+c].</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">class PhaseDeltaFilter(PhaseFilter):
     &#39;&#39;&#39;
-    Subtracts i atom&#39;s given keys with i+c atom&#39;s keys
-    Input:
-        Single stream ordered by datetime
-    Output:
-        Single stream containing n - c atoms
+    Subtracts i atom&#39;s given keys with i+c atom&#39;s keys.
+
+    Inputs:
+        Single stream ordered by datetime.
+    Outputs:
+        Single stream containing n - c atoms.
     &#39;&#39;&#39;
 
     def __init__(self, inputs: str, outputs: str, keys_to_change: Collection[str], distance: int):
@@ -221,7 +203,7 @@ Distance in number of atoms for which to calculate a[i] - a[i+c]</p></div>
             keys_to_change : Collection[str]
                 Collection of keys whom deltas will be calculated.
             distance : int
-                Distance in number of atoms for which to calculate a[i] - a[i+c]
+                Distance in number of atoms for which to calculate a[i] - a[i+c].
         &#39;&#39;&#39;
         super().__init__(
             inputs=inputs,
@@ -239,10 +221,10 @@ Distance in number of atoms for which to calculate a[i] - a[i+c]</p></div>
 <ul class="hlist">
 <li><code><b><a title="otri.filtering.filters.phase_filter.PhaseFilter" href="#otri.filtering.filters.phase_filter.PhaseFilter">PhaseFilter</a></b></code>:
 <ul class="hlist">
-<li><code><a title="otri.filtering.filters.phase_filter.PhaseFilter.execute" href="#otri.filtering.filters.phase_filter.PhaseFilter.execute">execute</a></code></li>
-<li><code><a title="otri.filtering.filters.phase_filter.PhaseFilter.get_inputs" href="../filter.html#otri.filtering.filter.Filter.get_inputs">get_inputs</a></code></li>
-<li><code><a title="otri.filtering.filters.phase_filter.PhaseFilter.get_outputs" href="../filter.html#otri.filtering.filter.Filter.get_outputs">get_outputs</a></code></li>
-<li><code><a title="otri.filtering.filters.phase_filter.PhaseFilter.setup" href="#otri.filtering.filters.phase_filter.PhaseFilter.setup">setup</a></code></li>
+<li><code><a title="otri.filtering.filters.phase_filter.PhaseFilter.execute" href="../filter.html#otri.filtering.filter.Filter.execute">execute</a></code></li>
+<li><code><a title="otri.filtering.filters.phase_filter.PhaseFilter.get_input_names" href="../filter.html#otri.filtering.filter.Filter.get_input_names">get_input_names</a></code></li>
+<li><code><a title="otri.filtering.filters.phase_filter.PhaseFilter.get_output_names" href="../filter.html#otri.filtering.filter.Filter.get_output_names">get_output_names</a></code></li>
+<li><code><a title="otri.filtering.filters.phase_filter.PhaseFilter.setup" href="../filter.html#otri.filtering.filter.Filter.setup">setup</a></code></li>
 </ul>
 </li>
 </ul>
@@ -253,9 +235,9 @@ Distance in number of atoms for which to calculate a[i] - a[i+c]</p></div>
 </code></dt>
 <dd>
 <div class="desc"><p>Applies an operation to the i atom's keys and i+c atom's keys.</p>
-<h2 id="input">Input</h2>
-<p>Single stream ordered by datetime</p>
-<h2 id="output">Output</h2>
+<h2 id="inputs">Inputs</h2>
+<p>Single stream ordered by datetime.</p>
+<h2 id="outputs">Outputs</h2>
 <p>Single stream containing n - c atoms, whose fields are the
 result of the given operation between the atoms at positions
 i and i+c in the input Stream. Such fields are the only fields
@@ -272,7 +254,7 @@ to use. Such operation should take two parameters and output a coherent value.
 These keys should be in all of the atoms of the Stream, to allow a proper output
 Stream. These will be the only keys in the output atoms.
 distance : int
-Distance in number of atoms to calculate a[i] * a[i+c]</p></div>
+Distance in number of atoms to calculate a[i] * a[i+c].</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -281,9 +263,9 @@ Distance in number of atoms to calculate a[i] * a[i+c]</p></div>
     &#39;&#39;&#39;
     Applies an operation to the i atom&#39;s keys and i+c atom&#39;s keys.
 
-    Input:
-        Single stream ordered by datetime
-    Output:
+    Inputs:
+        Single stream ordered by datetime.
+    Outputs:
         Single stream containing n - c atoms, whose fields are the
         result of the given operation between the atoms at positions
         i and i+c in the input Stream. Such fields are the only fields
@@ -304,7 +286,7 @@ Distance in number of atoms to calculate a[i] * a[i+c]</p></div>
                 These keys should be in all of the atoms of the Stream, to allow a proper output
                 Stream. These will be the only keys in the output atoms.
             distance : int
-                Distance in number of atoms to calculate a[i] * a[i+c]
+                Distance in number of atoms to calculate a[i] * a[i+c].
         &#39;&#39;&#39;
         super().__init__(
             inputs=[inputs],
@@ -317,22 +299,7 @@ Distance in number of atoms to calculate a[i] * a[i+c]</p></div>
         self.__atoms_buffer = list()
         self.__counter = 0
 
-    def setup(self, inputs: Sequence[Stream], outputs: Sequence[Stream], state: Mapping[str, Any]):
-        &#39;&#39;&#39;
-        Used to save references to streams and reset variables.
-        Called once before the start of the execution in FilterNet.
-
-        Parameters:
-            inputs, outputs : Sequence[Stream]
-                Ordered sequence containing the required input/output streams gained from the FilterNet.
-            state : Mapping[str, Any]
-                Dictionary containing states to output.
-        &#39;&#39;&#39;
-        self.__input = inputs[0]
-        self.__input_iter = iter(inputs[0])
-        self.__output = outputs[0]
-
-    def execute(self):
+    def _on_data(self, data, index):
         &#39;&#39;&#39;
         Pops atoms from the input Stream and places them in an internal buffer.
         When the internal buffer reaches the size of the requested distance we
@@ -340,23 +307,17 @@ Distance in number of atoms to calculate a[i] * a[i+c]</p></div>
         in the `keys_to_change` init parameter. The last `distance` parameters
         are discarded.
         &#39;&#39;&#39;
-        if(self.__output.is_closed()):
-            return
-
-        if(self.__input_iter.has_next()):
-            if(len(self.__atoms_buffer) &lt; self.__counter + 1):
-                self.__atoms_buffer.append(next(self.__input_iter))
-            else:
-                atom_1 = self.__atoms_buffer[self.__counter]
-                atom_2 = next(self.__input_iter)
-                mul_atom = dict()
-                for k in self.__keys.keys():
-                    mul_atom[k] = self.__keys[k](atom_1[k], atom_2[k])
-                self.__atoms_buffer[self.__counter] = atom_2
-                self.__output.append(mul_atom)
-            self.__counter = (self.__counter + 1) % self.__distance
-        elif(self.__input.is_closed()):
-            self.__output.close()</code></pre>
+        if(len(self.__atoms_buffer) &lt; self.__counter + 1):
+            self.__atoms_buffer.append(data)
+        else:
+            atom_1 = self.__atoms_buffer[self.__counter]
+            atom_2 = data
+            mul_atom = dict()
+            for k in self.__keys.keys():
+                mul_atom[k] = self.__keys[k](atom_1[k], atom_2[k])
+            self.__atoms_buffer[self.__counter] = atom_2
+            self._push_data(mul_atom)
+        self.__counter = (self.__counter + 1) % self.__distance</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">
@@ -367,86 +328,14 @@ Distance in number of atoms to calculate a[i] * a[i+c]</p></div>
 <li><a title="otri.filtering.filters.phase_filter.PhaseDeltaFilter" href="#otri.filtering.filters.phase_filter.PhaseDeltaFilter">PhaseDeltaFilter</a></li>
 <li><a title="otri.filtering.filters.phase_filter.PhaseMulFilter" href="#otri.filtering.filters.phase_filter.PhaseMulFilter">PhaseMulFilter</a></li>
 </ul>
-<h3>Methods</h3>
-<dl>
-<dt id="otri.filtering.filters.phase_filter.PhaseFilter.execute"><code class="name flex">
-<span>def <span class="ident">execute</span></span>(<span>self)</span>
-</code></dt>
-<dd>
-<div class="desc"><p>Pops atoms from the input Stream and places them in an internal buffer.
-When the internal buffer reaches the size of the requested distance we
-produce a new output atom whose fields are the results of the Callables
-in the <code>keys_to_change</code> init parameter. The last <code>distance</code> parameters
-are discarded.</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def execute(self):
-    &#39;&#39;&#39;
-    Pops atoms from the input Stream and places them in an internal buffer.
-    When the internal buffer reaches the size of the requested distance we
-    produce a new output atom whose fields are the results of the Callables
-    in the `keys_to_change` init parameter. The last `distance` parameters
-    are discarded.
-    &#39;&#39;&#39;
-    if(self.__output.is_closed()):
-        return
-
-    if(self.__input_iter.has_next()):
-        if(len(self.__atoms_buffer) &lt; self.__counter + 1):
-            self.__atoms_buffer.append(next(self.__input_iter))
-        else:
-            atom_1 = self.__atoms_buffer[self.__counter]
-            atom_2 = next(self.__input_iter)
-            mul_atom = dict()
-            for k in self.__keys.keys():
-                mul_atom[k] = self.__keys[k](atom_1[k], atom_2[k])
-            self.__atoms_buffer[self.__counter] = atom_2
-            self.__output.append(mul_atom)
-        self.__counter = (self.__counter + 1) % self.__distance
-    elif(self.__input.is_closed()):
-        self.__output.close()</code></pre>
-</details>
-</dd>
-<dt id="otri.filtering.filters.phase_filter.PhaseFilter.setup"><code class="name flex">
-<span>def <span class="ident">setup</span></span>(<span>self, inputs: Sequence[<a title="otri.filtering.stream.Stream" href="../stream.html#otri.filtering.stream.Stream">Stream</a>], outputs: Sequence[<a title="otri.filtering.stream.Stream" href="../stream.html#otri.filtering.stream.Stream">Stream</a>], state: Mapping[str, Any])</span>
-</code></dt>
-<dd>
-<div class="desc"><p>Used to save references to streams and reset variables.
-Called once before the start of the execution in FilterNet.</p>
-<h2 id="parameters">Parameters</h2>
-<p>inputs, outputs : Sequence[Stream]
-Ordered sequence containing the required input/output streams gained from the FilterNet.
-state : Mapping[str, Any]
-Dictionary containing states to output.</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def setup(self, inputs: Sequence[Stream], outputs: Sequence[Stream], state: Mapping[str, Any]):
-    &#39;&#39;&#39;
-    Used to save references to streams and reset variables.
-    Called once before the start of the execution in FilterNet.
-
-    Parameters:
-        inputs, outputs : Sequence[Stream]
-            Ordered sequence containing the required input/output streams gained from the FilterNet.
-        state : Mapping[str, Any]
-            Dictionary containing states to output.
-    &#39;&#39;&#39;
-    self.__input = inputs[0]
-    self.__input_iter = iter(inputs[0])
-    self.__output = outputs[0]</code></pre>
-</details>
-</dd>
-</dl>
 <h3>Inherited members</h3>
 <ul class="hlist">
 <li><code><b><a title="otri.filtering.filter.Filter" href="../filter.html#otri.filtering.filter.Filter">Filter</a></b></code>:
 <ul class="hlist">
-<li><code><a title="otri.filtering.filter.Filter.get_inputs" href="../filter.html#otri.filtering.filter.Filter.get_inputs">get_inputs</a></code></li>
-<li><code><a title="otri.filtering.filter.Filter.get_outputs" href="../filter.html#otri.filtering.filter.Filter.get_outputs">get_outputs</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.execute" href="../filter.html#otri.filtering.filter.Filter.execute">execute</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.get_input_names" href="../filter.html#otri.filtering.filter.Filter.get_input_names">get_input_names</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.get_output_names" href="../filter.html#otri.filtering.filter.Filter.get_output_names">get_output_names</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.setup" href="../filter.html#otri.filtering.filter.Filter.setup">setup</a></code></li>
 </ul>
 </li>
 </ul>
@@ -456,11 +345,11 @@ Dictionary containing states to output.</p></div>
 <span>(</span><span>inputs: str, outputs: str, keys_to_change: Collection[str], distance: int)</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Multiplies i atom's given keys with i+c atom's keys</p>
-<h2 id="input">Input</h2>
-<p>Single stream ordered by datetime</p>
-<h2 id="output">Output</h2>
-<p>Single stream containing n - c atoms</p>
+<div class="desc"><p>Multiplies i atom's given keys with i+c atom's keys.</p>
+<h2 id="inputs">Inputs</h2>
+<p>Single stream ordered by datetime.</p>
+<h2 id="outputs">Outputs</h2>
+<p>Single stream containing n - c atoms.</p>
 <h2 id="parameters">Parameters</h2>
 <p>inputs : str
 Input stream name.
@@ -469,18 +358,19 @@ Output stream name.
 keys_to_change : Collection[str]
 Collection of keys whom values will be multiplied.
 distance : int
-Distance in number of atoms to calculate a[i] * a[i+c]</p></div>
+Distance in number of atoms to calculate a[i] * a[i+c].</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
 </summary>
 <pre><code class="python">class PhaseMulFilter(PhaseFilter):
     &#39;&#39;&#39;
-    Multiplies i atom&#39;s given keys with i+c atom&#39;s keys
-    Input:
-        Single stream ordered by datetime
-    Output:
-        Single stream containing n - c atoms
+    Multiplies i atom&#39;s given keys with i+c atom&#39;s keys.
+
+    Inputs:
+        Single stream ordered by datetime.
+    Outputs:
+        Single stream containing n - c atoms.
     &#39;&#39;&#39;
 
     def __init__(self, inputs: str, outputs: str, keys_to_change: Collection[str], distance: int):
@@ -493,7 +383,7 @@ Distance in number of atoms to calculate a[i] * a[i+c]</p></div>
             keys_to_change : Collection[str]
                 Collection of keys whom values will be multiplied.
             distance : int
-                Distance in number of atoms to calculate a[i] * a[i+c]
+                Distance in number of atoms to calculate a[i] * a[i+c].
         &#39;&#39;&#39;
         super().__init__(
             inputs=inputs,
@@ -511,10 +401,10 @@ Distance in number of atoms to calculate a[i] * a[i+c]</p></div>
 <ul class="hlist">
 <li><code><b><a title="otri.filtering.filters.phase_filter.PhaseFilter" href="#otri.filtering.filters.phase_filter.PhaseFilter">PhaseFilter</a></b></code>:
 <ul class="hlist">
-<li><code><a title="otri.filtering.filters.phase_filter.PhaseFilter.execute" href="#otri.filtering.filters.phase_filter.PhaseFilter.execute">execute</a></code></li>
-<li><code><a title="otri.filtering.filters.phase_filter.PhaseFilter.get_inputs" href="../filter.html#otri.filtering.filter.Filter.get_inputs">get_inputs</a></code></li>
-<li><code><a title="otri.filtering.filters.phase_filter.PhaseFilter.get_outputs" href="../filter.html#otri.filtering.filter.Filter.get_outputs">get_outputs</a></code></li>
-<li><code><a title="otri.filtering.filters.phase_filter.PhaseFilter.setup" href="#otri.filtering.filters.phase_filter.PhaseFilter.setup">setup</a></code></li>
+<li><code><a title="otri.filtering.filters.phase_filter.PhaseFilter.execute" href="../filter.html#otri.filtering.filter.Filter.execute">execute</a></code></li>
+<li><code><a title="otri.filtering.filters.phase_filter.PhaseFilter.get_input_names" href="../filter.html#otri.filtering.filter.Filter.get_input_names">get_input_names</a></code></li>
+<li><code><a title="otri.filtering.filters.phase_filter.PhaseFilter.get_output_names" href="../filter.html#otri.filtering.filter.Filter.get_output_names">get_output_names</a></code></li>
+<li><code><a title="otri.filtering.filters.phase_filter.PhaseFilter.setup" href="../filter.html#otri.filtering.filter.Filter.setup">setup</a></code></li>
 </ul>
 </li>
 </ul>
@@ -540,10 +430,6 @@ Distance in number of atoms to calculate a[i] * a[i+c]</p></div>
 </li>
 <li>
 <h4><code><a title="otri.filtering.filters.phase_filter.PhaseFilter" href="#otri.filtering.filters.phase_filter.PhaseFilter">PhaseFilter</a></code></h4>
-<ul class="">
-<li><code><a title="otri.filtering.filters.phase_filter.PhaseFilter.execute" href="#otri.filtering.filters.phase_filter.PhaseFilter.execute">execute</a></code></li>
-<li><code><a title="otri.filtering.filters.phase_filter.PhaseFilter.setup" href="#otri.filtering.filters.phase_filter.PhaseFilter.setup">setup</a></code></li>
-</ul>
 </li>
 <li>
 <h4><code><a title="otri.filtering.filters.phase_filter.PhaseMulFilter" href="#otri.filtering.filters.phase_filter.PhaseMulFilter">PhaseMulFilter</a></code></h4>

--- a/doc/otri/filtering/filters/split_filter.html
+++ b/doc/otri/filtering/filters/split_filter.html
@@ -34,13 +34,16 @@ import numpy
 class SplitFilter(Filter):
     &#39;&#39;&#39;
     Splits a Stream based on the value range of a numerical field in the atoms.
-    Inputs: a single Stream.
-    Outputs: Multiple Streams, as many as the possible value ranges are, plus one for the
-    atoms that do not have the given key, if enabled. The indexes will be treated as:
-    0 for the left-most interval (less than r1),
-    1 for the second interval (r1 to r2),
-    and so on. If atoms that do not have the given key are not to be ignored, the stream
-    will be the last one (of index n+1).
+
+    Inputs:
+        A single stream.
+    Outputs:
+        Multiple Streams, as many as the possible value ranges are, plus one for the
+        atoms that do not have the given key, if enabled. The indexes will be treated as:
+        0 for the left-most interval (less than r1),
+        1 for the second interval (r1 to r2),
+        and so on. If atoms that do not have the given key are not to be ignored, the stream
+        will be the last one (of index n+1).
     &#39;&#39;&#39;
 
     def __init__(self, inputs: str, outputs: Sequence[str], key: Any, ranges: Sequence, none_keys_output: str = None, side: str = &#39;left&#39;):
@@ -68,7 +71,7 @@ class SplitFilter(Filter):
                 If None is given the atoms will be ignored, deleted.
             side : str = &#39;left&#39;
                 Same as `numpy.searchsorted`. &#39;left&#39; makes an interval from v1 to v2 as ]v1,v2], while &#39;right&#39;
-                makes an interval as [v1,v2[. 
+                makes an interval as [v1,v2[.
         &#39;&#39;&#39;
         n = len(ranges)
         if none_keys_output != None:
@@ -91,60 +94,42 @@ class SplitFilter(Filter):
         &#39;&#39;&#39;
         Used to save references to streams and reset variables.
         Called once before the start of the execution in FilterNet.
-
-        Parameters:
-            inputs, outputs : Sequence[Stream]
-                Ordered sequence containing the required input/output streams gained from the FilterNet.
-            state : Mapping[str, Any]
-                Dictionary containing states to output.
         &#39;&#39;&#39;
+        super().setup(inputs, outputs, state)
+        # Keeping the following lines just to be sure
         n = len(self.__ranges)
         out_count = n + 1 if self.__ignore_none else n + 2
         if len(outputs) != out_count:
             raise AttributeError(&#34;SplitFilter requires {} output streams, {} given&#34;.format(
                 out_count, len(outputs)))
-        self.__input = inputs[0]
-        self.__input_iter = iter(inputs[0])
-        self.__outputs = outputs
-        if not self.__ignore_none:
-            self.__none_output = outputs[len(outputs) - 1]
 
-    def execute(self):
+    def _on_data(self, data, index):
         &#39;&#39;&#39;
-        Attempts to fetch a single atom from the input stream. Puts it into the appropriate output stream.
-        If the atoms that do not have the key should be discarded, it also attempts to fetch another one
-        immediately.
+        Puts the atom into the appropriate output stream.
+        Atoms that do not have the key can be either discarded or placed into the &#39;none_keys&#39; output, the last one.
         &#39;&#39;&#39;
-        # Assumes that all outputs must be closed at once.
-        if self.__outputs[0].is_closed():
-            return
-        if self.__input_iter.has_next():
-            item = next(self.__input_iter)
-            if self.__key in item.keys():
-                # Find the appropriate Stream for the item.
-                self.__outputs[numpy.searchsorted(
-                    self.__ranges, item[self.__key], self.__side
-                )].append(item)
-            else:
-                # Ignoring the item that does not have the key.
-                if not self.__ignore_none:
-                    # Append void atom on last output
-                    self.__none_output.append(item)
-        elif self.__input.is_closed():
-            # Closed input -&gt; Close outputs
-            for output in self.__outputs:
-                output.close()
+        if self.__key in data.keys():
+            # Find the appropriate Stream for the item.
+            self._push_data(data, numpy.searchsorted(self.__ranges, data[self.__key], self.__side))
+        else:
+            # Ignoring the item that does not have the key.
+            if not self.__ignore_none:
+                # Append void atom on last output
+                self._push_data(data, len(self.get_output_names()) - 1)
 
 
 class SwitchFilter(Filter):
     &#39;&#39;&#39;
     Splits a Stream based on the value of a field in the atoms.
-    Inputs: a single Stream.
-    Outputs: Multiple Streams, as many as the requested cases (N), plus one for the default case,
-    and one for the atoms that do not have the requested key, if enabled.
-    Output streams of index 0 to N-1 will be the cases, N will be the default, N+1 will be
-    for atoms that do not have the key (if enabled). N and N+1 are guaranteed, but the case
-    ordering is not.
+
+    Inputs:
+        A single stream.
+    Outputs:
+        Multiple Streams, as many as the requested cases (N), plus one for the default case,
+        and one for the atoms that do not have the requested key, if enabled.
+        Output streams of index 0 to N-1 will be the cases, N will be the default, N+1 will be
+        for atoms that do not have the key (if enabled). N and N+1 are guaranteed, but the case
+        ordering is not.
     &#39;&#39;&#39;
 
     def __init__(self, inputs: str, cases_outputs: Sequence[str], default_output: str, key: Any, cases: Set, none_keys_output: str = None):
@@ -195,57 +180,29 @@ class SwitchFilter(Filter):
             state : Mapping[str, Any]
                 Dictionary containing states to output.
         &#39;&#39;&#39;
-        self.__input = inputs[0]
-        self.__input_iter = iter(inputs[0])
-        self.__outputs = outputs
+        super().setup(inputs, outputs, state)
         if not self.__ignore_none:
-            self.__default_output = outputs[len(outputs) - 2]
-            self.__none_output = outputs[len(outputs) - 1]
+            self.__default_index = len(outputs) - 2
+            self.__none_index = len(outputs) - 1
         else:
-            self.__default_output = outputs[len(outputs) - 1]
-        self.__cases_outputs = {
-            case: outputs[i]
-            for i, case in enumerate(self.__cases)
-        }
+            self.__default_index = len(outputs) - 1
 
-    def __get_case_output_stream(self, case: Any):
+    def _on_data(self, data, index):
         &#39;&#39;&#39;
-        Parameters:
-            case : Any
-                One of the cases for this filter
-        Returns: Stream
-            The output Stream relative to the case
-        Raises:
-            KeyError : if the case was not in the cases provided as init parameter.
+        Puts the atom into the appropriate output stream.
+        Atoms that do not have the key can be either discarded or placed into the &#39;none_keys&#39; output, the last one.
+        Atoms which key&#39;s value is not in one of the cases are placed inside the &#39;default&#39; output, either the last one or the second last.
         &#39;&#39;&#39;
-        return self.__cases_outputs[case]
-
-    def execute(self):
-        &#39;&#39;&#39;
-        Attempts to fetch a single atom from the input stream. Puts it into the appropriate output stream.
-        If the atoms that do not have the key should be discarded, it also attempts to fetch another one
-        immediately.
-        &#39;&#39;&#39;
-        # Assumes that all outputs must be closed at once.
-        key = self.__key
-        if self.__outputs[0].is_closed():
-            return
-        if self.__input_iter.has_next():
-            item = next(self.__input_iter)
-            if key in item.keys():
-                # Put the atom in the appropriate output stream.
-                if item[key] in self.__cases:
-                    self.__cases_outputs[item[key]].append(item)
-                else:
-                    self.__default_output.append(item)
+        if self.__key in data.keys():
+            # Put the atom in the appropriate output stream.
+            if data[self.__key] in self.__cases:
+                case_index = self.__cases.index(data[self.__key])
+                self._push_data(data, case_index)
             else:
-                if not self.__ignore_none:
-                    # Putting the item in the dedicated Stream.
-                    self.__none_output.append(item)
-        elif self.__input.is_closed():
-            # Closed input -&gt; Close outputs
-            for output in self.__outputs:
-                output.close()</code></pre>
+                self._push_data(data, self.__default_index)
+        else:
+            if not self.__ignore_none:
+                self._push_data(data, self.__none_index)</code></pre>
 </details>
 </section>
 <section>
@@ -262,9 +219,11 @@ class SwitchFilter(Filter):
 <span>(</span><span>inputs: str, outputs: Sequence[str], key: Any, ranges: Sequence, none_keys_output: str = None, side: str = 'left')</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Splits a Stream based on the value range of a numerical field in the atoms.
-Inputs: a single Stream.
-Outputs: Multiple Streams, as many as the possible value ranges are, plus one for the
+<div class="desc"><p>Splits a Stream based on the value range of a numerical field in the atoms.</p>
+<h2 id="inputs">Inputs</h2>
+<p>A single stream.</p>
+<h2 id="outputs">Outputs</h2>
+<p>Multiple Streams, as many as the possible value ranges are, plus one for the
 atoms that do not have the given key, if enabled. The indexes will be treated as:
 0 for the left-most interval (less than r1),
 1 for the second interval (r1 to r2),
@@ -301,13 +260,16 @@ makes an interval as [v1,v2[.</p></div>
 <pre><code class="python">class SplitFilter(Filter):
     &#39;&#39;&#39;
     Splits a Stream based on the value range of a numerical field in the atoms.
-    Inputs: a single Stream.
-    Outputs: Multiple Streams, as many as the possible value ranges are, plus one for the
-    atoms that do not have the given key, if enabled. The indexes will be treated as:
-    0 for the left-most interval (less than r1),
-    1 for the second interval (r1 to r2),
-    and so on. If atoms that do not have the given key are not to be ignored, the stream
-    will be the last one (of index n+1).
+
+    Inputs:
+        A single stream.
+    Outputs:
+        Multiple Streams, as many as the possible value ranges are, plus one for the
+        atoms that do not have the given key, if enabled. The indexes will be treated as:
+        0 for the left-most interval (less than r1),
+        1 for the second interval (r1 to r2),
+        and so on. If atoms that do not have the given key are not to be ignored, the stream
+        will be the last one (of index n+1).
     &#39;&#39;&#39;
 
     def __init__(self, inputs: str, outputs: Sequence[str], key: Any, ranges: Sequence, none_keys_output: str = None, side: str = &#39;left&#39;):
@@ -335,7 +297,7 @@ makes an interval as [v1,v2[.</p></div>
                 If None is given the atoms will be ignored, deleted.
             side : str = &#39;left&#39;
                 Same as `numpy.searchsorted`. &#39;left&#39; makes an interval from v1 to v2 as ]v1,v2], while &#39;right&#39;
-                makes an interval as [v1,v2[. 
+                makes an interval as [v1,v2[.
         &#39;&#39;&#39;
         n = len(ranges)
         if none_keys_output != None:
@@ -358,49 +320,28 @@ makes an interval as [v1,v2[.</p></div>
         &#39;&#39;&#39;
         Used to save references to streams and reset variables.
         Called once before the start of the execution in FilterNet.
-
-        Parameters:
-            inputs, outputs : Sequence[Stream]
-                Ordered sequence containing the required input/output streams gained from the FilterNet.
-            state : Mapping[str, Any]
-                Dictionary containing states to output.
         &#39;&#39;&#39;
+        super().setup(inputs, outputs, state)
+        # Keeping the following lines just to be sure
         n = len(self.__ranges)
         out_count = n + 1 if self.__ignore_none else n + 2
         if len(outputs) != out_count:
             raise AttributeError(&#34;SplitFilter requires {} output streams, {} given&#34;.format(
                 out_count, len(outputs)))
-        self.__input = inputs[0]
-        self.__input_iter = iter(inputs[0])
-        self.__outputs = outputs
-        if not self.__ignore_none:
-            self.__none_output = outputs[len(outputs) - 1]
 
-    def execute(self):
+    def _on_data(self, data, index):
         &#39;&#39;&#39;
-        Attempts to fetch a single atom from the input stream. Puts it into the appropriate output stream.
-        If the atoms that do not have the key should be discarded, it also attempts to fetch another one
-        immediately.
+        Puts the atom into the appropriate output stream.
+        Atoms that do not have the key can be either discarded or placed into the &#39;none_keys&#39; output, the last one.
         &#39;&#39;&#39;
-        # Assumes that all outputs must be closed at once.
-        if self.__outputs[0].is_closed():
-            return
-        if self.__input_iter.has_next():
-            item = next(self.__input_iter)
-            if self.__key in item.keys():
-                # Find the appropriate Stream for the item.
-                self.__outputs[numpy.searchsorted(
-                    self.__ranges, item[self.__key], self.__side
-                )].append(item)
-            else:
-                # Ignoring the item that does not have the key.
-                if not self.__ignore_none:
-                    # Append void atom on last output
-                    self.__none_output.append(item)
-        elif self.__input.is_closed():
-            # Closed input -&gt; Close outputs
-            for output in self.__outputs:
-                output.close()</code></pre>
+        if self.__key in data.keys():
+            # Find the appropriate Stream for the item.
+            self._push_data(data, numpy.searchsorted(self.__ranges, data[self.__key], self.__side))
+        else:
+            # Ignoring the item that does not have the key.
+            if not self.__ignore_none:
+                # Append void atom on last output
+                self._push_data(data, len(self.get_output_names()) - 1)</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">
@@ -408,55 +349,12 @@ makes an interval as [v1,v2[.</p></div>
 </ul>
 <h3>Methods</h3>
 <dl>
-<dt id="otri.filtering.filters.split_filter.SplitFilter.execute"><code class="name flex">
-<span>def <span class="ident">execute</span></span>(<span>self)</span>
-</code></dt>
-<dd>
-<div class="desc"><p>Attempts to fetch a single atom from the input stream. Puts it into the appropriate output stream.
-If the atoms that do not have the key should be discarded, it also attempts to fetch another one
-immediately.</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def execute(self):
-    &#39;&#39;&#39;
-    Attempts to fetch a single atom from the input stream. Puts it into the appropriate output stream.
-    If the atoms that do not have the key should be discarded, it also attempts to fetch another one
-    immediately.
-    &#39;&#39;&#39;
-    # Assumes that all outputs must be closed at once.
-    if self.__outputs[0].is_closed():
-        return
-    if self.__input_iter.has_next():
-        item = next(self.__input_iter)
-        if self.__key in item.keys():
-            # Find the appropriate Stream for the item.
-            self.__outputs[numpy.searchsorted(
-                self.__ranges, item[self.__key], self.__side
-            )].append(item)
-        else:
-            # Ignoring the item that does not have the key.
-            if not self.__ignore_none:
-                # Append void atom on last output
-                self.__none_output.append(item)
-    elif self.__input.is_closed():
-        # Closed input -&gt; Close outputs
-        for output in self.__outputs:
-            output.close()</code></pre>
-</details>
-</dd>
 <dt id="otri.filtering.filters.split_filter.SplitFilter.setup"><code class="name flex">
 <span>def <span class="ident">setup</span></span>(<span>self, inputs: Sequence[<a title="otri.filtering.stream.Stream" href="../stream.html#otri.filtering.stream.Stream">Stream</a>], outputs: Sequence[<a title="otri.filtering.stream.Stream" href="../stream.html#otri.filtering.stream.Stream">Stream</a>], state: Mapping[str, Any])</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Used to save references to streams and reset variables.
-Called once before the start of the execution in FilterNet.</p>
-<h2 id="parameters">Parameters</h2>
-<p>inputs, outputs : Sequence[Stream]
-Ordered sequence containing the required input/output streams gained from the FilterNet.
-state : Mapping[str, Any]
-Dictionary containing states to output.</p></div>
+Called once before the start of the execution in FilterNet.</p></div>
 <details class="source">
 <summary>
 <span>Expand source code</span>
@@ -465,23 +363,14 @@ Dictionary containing states to output.</p></div>
     &#39;&#39;&#39;
     Used to save references to streams and reset variables.
     Called once before the start of the execution in FilterNet.
-
-    Parameters:
-        inputs, outputs : Sequence[Stream]
-            Ordered sequence containing the required input/output streams gained from the FilterNet.
-        state : Mapping[str, Any]
-            Dictionary containing states to output.
     &#39;&#39;&#39;
+    super().setup(inputs, outputs, state)
+    # Keeping the following lines just to be sure
     n = len(self.__ranges)
     out_count = n + 1 if self.__ignore_none else n + 2
     if len(outputs) != out_count:
         raise AttributeError(&#34;SplitFilter requires {} output streams, {} given&#34;.format(
-            out_count, len(outputs)))
-    self.__input = inputs[0]
-    self.__input_iter = iter(inputs[0])
-    self.__outputs = outputs
-    if not self.__ignore_none:
-        self.__none_output = outputs[len(outputs) - 1]</code></pre>
+            out_count, len(outputs)))</code></pre>
 </details>
 </dd>
 </dl>
@@ -489,8 +378,9 @@ Dictionary containing states to output.</p></div>
 <ul class="hlist">
 <li><code><b><a title="otri.filtering.filter.Filter" href="../filter.html#otri.filtering.filter.Filter">Filter</a></b></code>:
 <ul class="hlist">
-<li><code><a title="otri.filtering.filter.Filter.get_inputs" href="../filter.html#otri.filtering.filter.Filter.get_inputs">get_inputs</a></code></li>
-<li><code><a title="otri.filtering.filter.Filter.get_outputs" href="../filter.html#otri.filtering.filter.Filter.get_outputs">get_outputs</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.execute" href="../filter.html#otri.filtering.filter.Filter.execute">execute</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.get_input_names" href="../filter.html#otri.filtering.filter.Filter.get_input_names">get_input_names</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.get_output_names" href="../filter.html#otri.filtering.filter.Filter.get_output_names">get_output_names</a></code></li>
 </ul>
 </li>
 </ul>
@@ -500,9 +390,11 @@ Dictionary containing states to output.</p></div>
 <span>(</span><span>inputs: str, cases_outputs: Sequence[str], default_output: str, key: Any, cases: Set, none_keys_output: str = None)</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Splits a Stream based on the value of a field in the atoms.
-Inputs: a single Stream.
-Outputs: Multiple Streams, as many as the requested cases (N), plus one for the default case,
+<div class="desc"><p>Splits a Stream based on the value of a field in the atoms.</p>
+<h2 id="inputs">Inputs</h2>
+<p>A single stream.</p>
+<h2 id="outputs">Outputs</h2>
+<p>Multiple Streams, as many as the requested cases (N), plus one for the default case,
 and one for the atoms that do not have the requested key, if enabled.
 Output streams of index 0 to N-1 will be the cases, N will be the default, N+1 will be
 for atoms that do not have the key (if enabled). N and N+1 are guaranteed, but the case
@@ -530,12 +422,15 @@ If None is given the atoms will be ignored, deleted.</p></div>
 <pre><code class="python">class SwitchFilter(Filter):
     &#39;&#39;&#39;
     Splits a Stream based on the value of a field in the atoms.
-    Inputs: a single Stream.
-    Outputs: Multiple Streams, as many as the requested cases (N), plus one for the default case,
-    and one for the atoms that do not have the requested key, if enabled.
-    Output streams of index 0 to N-1 will be the cases, N will be the default, N+1 will be
-    for atoms that do not have the key (if enabled). N and N+1 are guaranteed, but the case
-    ordering is not.
+
+    Inputs:
+        A single stream.
+    Outputs:
+        Multiple Streams, as many as the requested cases (N), plus one for the default case,
+        and one for the atoms that do not have the requested key, if enabled.
+        Output streams of index 0 to N-1 will be the cases, N will be the default, N+1 will be
+        for atoms that do not have the key (if enabled). N and N+1 are guaranteed, but the case
+        ordering is not.
     &#39;&#39;&#39;
 
     def __init__(self, inputs: str, cases_outputs: Sequence[str], default_output: str, key: Any, cases: Set, none_keys_output: str = None):
@@ -586,57 +481,29 @@ If None is given the atoms will be ignored, deleted.</p></div>
             state : Mapping[str, Any]
                 Dictionary containing states to output.
         &#39;&#39;&#39;
-        self.__input = inputs[0]
-        self.__input_iter = iter(inputs[0])
-        self.__outputs = outputs
+        super().setup(inputs, outputs, state)
         if not self.__ignore_none:
-            self.__default_output = outputs[len(outputs) - 2]
-            self.__none_output = outputs[len(outputs) - 1]
+            self.__default_index = len(outputs) - 2
+            self.__none_index = len(outputs) - 1
         else:
-            self.__default_output = outputs[len(outputs) - 1]
-        self.__cases_outputs = {
-            case: outputs[i]
-            for i, case in enumerate(self.__cases)
-        }
+            self.__default_index = len(outputs) - 1
 
-    def __get_case_output_stream(self, case: Any):
+    def _on_data(self, data, index):
         &#39;&#39;&#39;
-        Parameters:
-            case : Any
-                One of the cases for this filter
-        Returns: Stream
-            The output Stream relative to the case
-        Raises:
-            KeyError : if the case was not in the cases provided as init parameter.
+        Puts the atom into the appropriate output stream.
+        Atoms that do not have the key can be either discarded or placed into the &#39;none_keys&#39; output, the last one.
+        Atoms which key&#39;s value is not in one of the cases are placed inside the &#39;default&#39; output, either the last one or the second last.
         &#39;&#39;&#39;
-        return self.__cases_outputs[case]
-
-    def execute(self):
-        &#39;&#39;&#39;
-        Attempts to fetch a single atom from the input stream. Puts it into the appropriate output stream.
-        If the atoms that do not have the key should be discarded, it also attempts to fetch another one
-        immediately.
-        &#39;&#39;&#39;
-        # Assumes that all outputs must be closed at once.
-        key = self.__key
-        if self.__outputs[0].is_closed():
-            return
-        if self.__input_iter.has_next():
-            item = next(self.__input_iter)
-            if key in item.keys():
-                # Put the atom in the appropriate output stream.
-                if item[key] in self.__cases:
-                    self.__cases_outputs[item[key]].append(item)
-                else:
-                    self.__default_output.append(item)
+        if self.__key in data.keys():
+            # Put the atom in the appropriate output stream.
+            if data[self.__key] in self.__cases:
+                case_index = self.__cases.index(data[self.__key])
+                self._push_data(data, case_index)
             else:
-                if not self.__ignore_none:
-                    # Putting the item in the dedicated Stream.
-                    self.__none_output.append(item)
-        elif self.__input.is_closed():
-            # Closed input -&gt; Close outputs
-            for output in self.__outputs:
-                output.close()</code></pre>
+                self._push_data(data, self.__default_index)
+        else:
+            if not self.__ignore_none:
+                self._push_data(data, self.__none_index)</code></pre>
 </details>
 <h3>Ancestors</h3>
 <ul class="hlist">
@@ -644,45 +511,6 @@ If None is given the atoms will be ignored, deleted.</p></div>
 </ul>
 <h3>Methods</h3>
 <dl>
-<dt id="otri.filtering.filters.split_filter.SwitchFilter.execute"><code class="name flex">
-<span>def <span class="ident">execute</span></span>(<span>self)</span>
-</code></dt>
-<dd>
-<div class="desc"><p>Attempts to fetch a single atom from the input stream. Puts it into the appropriate output stream.
-If the atoms that do not have the key should be discarded, it also attempts to fetch another one
-immediately.</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def execute(self):
-    &#39;&#39;&#39;
-    Attempts to fetch a single atom from the input stream. Puts it into the appropriate output stream.
-    If the atoms that do not have the key should be discarded, it also attempts to fetch another one
-    immediately.
-    &#39;&#39;&#39;
-    # Assumes that all outputs must be closed at once.
-    key = self.__key
-    if self.__outputs[0].is_closed():
-        return
-    if self.__input_iter.has_next():
-        item = next(self.__input_iter)
-        if key in item.keys():
-            # Put the atom in the appropriate output stream.
-            if item[key] in self.__cases:
-                self.__cases_outputs[item[key]].append(item)
-            else:
-                self.__default_output.append(item)
-        else:
-            if not self.__ignore_none:
-                # Putting the item in the dedicated Stream.
-                self.__none_output.append(item)
-    elif self.__input.is_closed():
-        # Closed input -&gt; Close outputs
-        for output in self.__outputs:
-            output.close()</code></pre>
-</details>
-</dd>
 <dt id="otri.filtering.filters.split_filter.SwitchFilter.setup"><code class="name flex">
 <span>def <span class="ident">setup</span></span>(<span>self, inputs: Sequence[<a title="otri.filtering.stream.Stream" href="../stream.html#otri.filtering.stream.Stream">Stream</a>], outputs: Sequence[<a title="otri.filtering.stream.Stream" href="../stream.html#otri.filtering.stream.Stream">Stream</a>], state: Mapping[str, Any])</span>
 </code></dt>
@@ -709,18 +537,12 @@ Dictionary containing states to output.</p></div>
         state : Mapping[str, Any]
             Dictionary containing states to output.
     &#39;&#39;&#39;
-    self.__input = inputs[0]
-    self.__input_iter = iter(inputs[0])
-    self.__outputs = outputs
+    super().setup(inputs, outputs, state)
     if not self.__ignore_none:
-        self.__default_output = outputs[len(outputs) - 2]
-        self.__none_output = outputs[len(outputs) - 1]
+        self.__default_index = len(outputs) - 2
+        self.__none_index = len(outputs) - 1
     else:
-        self.__default_output = outputs[len(outputs) - 1]
-    self.__cases_outputs = {
-        case: outputs[i]
-        for i, case in enumerate(self.__cases)
-    }</code></pre>
+        self.__default_index = len(outputs) - 1</code></pre>
 </details>
 </dd>
 </dl>
@@ -728,8 +550,9 @@ Dictionary containing states to output.</p></div>
 <ul class="hlist">
 <li><code><b><a title="otri.filtering.filter.Filter" href="../filter.html#otri.filtering.filter.Filter">Filter</a></b></code>:
 <ul class="hlist">
-<li><code><a title="otri.filtering.filter.Filter.get_inputs" href="../filter.html#otri.filtering.filter.Filter.get_inputs">get_inputs</a></code></li>
-<li><code><a title="otri.filtering.filter.Filter.get_outputs" href="../filter.html#otri.filtering.filter.Filter.get_outputs">get_outputs</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.execute" href="../filter.html#otri.filtering.filter.Filter.execute">execute</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.get_input_names" href="../filter.html#otri.filtering.filter.Filter.get_input_names">get_input_names</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.get_output_names" href="../filter.html#otri.filtering.filter.Filter.get_output_names">get_output_names</a></code></li>
 </ul>
 </li>
 </ul>
@@ -753,14 +576,12 @@ Dictionary containing states to output.</p></div>
 <li>
 <h4><code><a title="otri.filtering.filters.split_filter.SplitFilter" href="#otri.filtering.filters.split_filter.SplitFilter">SplitFilter</a></code></h4>
 <ul class="">
-<li><code><a title="otri.filtering.filters.split_filter.SplitFilter.execute" href="#otri.filtering.filters.split_filter.SplitFilter.execute">execute</a></code></li>
 <li><code><a title="otri.filtering.filters.split_filter.SplitFilter.setup" href="#otri.filtering.filters.split_filter.SplitFilter.setup">setup</a></code></li>
 </ul>
 </li>
 <li>
 <h4><code><a title="otri.filtering.filters.split_filter.SwitchFilter" href="#otri.filtering.filters.split_filter.SwitchFilter">SwitchFilter</a></code></h4>
 <ul class="">
-<li><code><a title="otri.filtering.filters.split_filter.SwitchFilter.execute" href="#otri.filtering.filters.split_filter.SwitchFilter.execute">execute</a></code></li>
 <li><code><a title="otri.filtering.filters.split_filter.SwitchFilter.setup" href="#otri.filtering.filters.split_filter.SwitchFilter.setup">setup</a></code></li>
 </ul>
 </li>

--- a/doc/otri/filtering/filters/statistics_filter.html
+++ b/doc/otri/filtering/filters/statistics_filter.html
@@ -33,12 +33,11 @@ from numbers import Number
 
 class StatisticsFilter(Filter):
     &#39;&#39;&#39;
-    Pops a single piece of data, reads the fields in the `keys` init parameter, updates the state
-    and outputs the data unmodified.
+    Reads the fields in the `keys` init parameter, updates the state and outputs the data unmodified.
 
-    Input:
+    Inputs:
         Single stream.
-    Output:
+    Outputs:
         Single stream.
     &#39;&#39;&#39;
 
@@ -62,41 +61,37 @@ class StatisticsFilter(Filter):
         # Dict like : {callable : state_name}
         self.__ops = dict()
 
-    def setup(self, inputs : Sequence[Stream], outputs : Sequence[Stream], state: Mapping[str, Any]):
+    def setup(self, inputs: Sequence[Stream], outputs: Sequence[Stream], state: Mapping[str, Any]):
         &#39;&#39;&#39;
         Used to save references to streams and reset variables.
         Called once before the start of the execution in FilterNet.
-        
+
         Parameters:
             inputs, outputs : Sequence[Stream]
                 Ordered sequence containing the required input/output streams gained from the FilterNet.
             state : Mapping[str, Any]
                 Dictionary containing states to output.
         &#39;&#39;&#39;
-        self.__input = inputs[0]
-        self.__input_iter = iter(inputs[0])
-        self.__output = outputs[0]
+        # Call superclass setup
+        super().setup(inputs, outputs, state)
+        # Save the state instance
         self.__state = state
+        # Check if state name is already used, otherwise init a dict
         for stat_name in self.__ops.values():
             if state.get(stat_name, None) != None:
                 raise(ValueError(&#34;state &#39;{}&#39; uses duplicate name&#34;.format(stat_name)))
             state[stat_name] = dict()
 
-    def execute(self):
+    def _on_data(self, data, index):
         &#39;&#39;&#39;
         Pops a single piece of data, reads the fields in the `keys` init parameter, updates the state
         and outputs the data unmodified.
         &#39;&#39;&#39;
-        if self.__output.is_closed():
-            return
-        if self.__input_iter.has_next():
-            atom = next(self.__input_iter)
-            for op, stat_name in self.__ops.items():
-                op(atom, stat_name)
-            self.__output.append(atom)
-        # Check that we didn&#39;t just pop the last item
-        elif self.__input.is_closed():
-            self.__output.close()
+        # Update all of the operations
+        for op, stat_name in self.__ops.items():
+            op(data, stat_name)
+        # Output data unmodified
+        self._push_data(data)
 
     def calc_avg(self, state_name: str):
         &#39;&#39;&#39;
@@ -161,15 +156,15 @@ class StatisticsFilter(Filter):
         self.__ops[self.__min] = state_name
         return self
 
-    def __sum(self, atom: Mapping, stat_name : str):
+    def __sum(self, atom: Mapping, stat_name: str):
         &#39;&#39;&#39;
         Update the sum state for the given keys.
         &#39;&#39;&#39;
         for k in self.__keys:
             if k in atom.keys():
-                self.__state[stat_name][k] = self.__state[stat_name].setdefault(k,0) + atom[k]
+                self.__state[stat_name][k] = self.__state[stat_name].setdefault(k, 0) + atom[k]
 
-    def __count(self, atom: Mapping, stat_name : str):
+    def __count(self, atom: Mapping, stat_name: str):
         &#39;&#39;&#39;
         Update the count state for the given keys.
         &#39;&#39;&#39;
@@ -177,7 +172,7 @@ class StatisticsFilter(Filter):
             if k in atom.keys():
                 self.__state[stat_name][k] = self.__state[stat_name].setdefault(k, 0) + 1
 
-    def __max(self, atom: Mapping, stat_name : str):
+    def __max(self, atom: Mapping, stat_name: str):
         &#39;&#39;&#39;
         Update the max state for the given keys.
         &#39;&#39;&#39;
@@ -186,7 +181,7 @@ class StatisticsFilter(Filter):
                 old_val = self.__state[stat_name].setdefault(k, float(&#39;-inf&#39;))
                 self.__state[stat_name][k] = max(old_val, atom[k])
 
-    def __min(self, atom: Mapping, stat_name : str):
+    def __min(self, atom: Mapping, stat_name: str):
         &#39;&#39;&#39;
         Update the min state for the given keys.
         &#39;&#39;&#39;
@@ -195,14 +190,15 @@ class StatisticsFilter(Filter):
                 old_val = self.__state[stat_name].setdefault(k, float(&#39;inf&#39;))
                 self.__state[stat_name][k] = min(old_val, atom[k])
 
-    def __avg(self, atom : Mapping, stat_name : str):
+    def __avg(self, atom: Mapping, stat_name: str):
         &#39;&#39;&#39;
         Update the avg state for the given keys.
         &#39;&#39;&#39;
         for k in self.__keys:
             if k in atom.keys():
-                if(self.__state[self.__ops[self.__count]].setdefault(k,0) != 0):
-                    avg = self.__state[self.__ops[self.__sum]].setdefault(k,0) / self.__state[self.__ops[self.__count]][k]
+                if(self.__state[self.__ops[self.__count]].setdefault(k, 0) != 0):
+                    avg = self.__state[self.__ops[self.__sum]].setdefault(
+                        k, 0) / self.__state[self.__ops[self.__count]][k]
                     self.__state[stat_name][k] = avg</code></pre>
 </details>
 </section>
@@ -220,11 +216,10 @@ class StatisticsFilter(Filter):
 <span>(</span><span>inputs: str, outputs: str, keys: Collection[str])</span>
 </code></dt>
 <dd>
-<div class="desc"><p>Pops a single piece of data, reads the fields in the <code>keys</code> init parameter, updates the state
-and outputs the data unmodified.</p>
-<h2 id="input">Input</h2>
+<div class="desc"><p>Reads the fields in the <code>keys</code> init parameter, updates the state and outputs the data unmodified.</p>
+<h2 id="inputs">Inputs</h2>
 <p>Single stream.</p>
-<h2 id="output">Output</h2>
+<h2 id="outputs">Outputs</h2>
 <p>Single stream.</p>
 <h2 id="parameters">Parameters</h2>
 <p>inputs : str
@@ -239,12 +234,11 @@ The keys for which to compute the stats.</p></div>
 </summary>
 <pre><code class="python">class StatisticsFilter(Filter):
     &#39;&#39;&#39;
-    Pops a single piece of data, reads the fields in the `keys` init parameter, updates the state
-    and outputs the data unmodified.
+    Reads the fields in the `keys` init parameter, updates the state and outputs the data unmodified.
 
-    Input:
+    Inputs:
         Single stream.
-    Output:
+    Outputs:
         Single stream.
     &#39;&#39;&#39;
 
@@ -268,41 +262,37 @@ The keys for which to compute the stats.</p></div>
         # Dict like : {callable : state_name}
         self.__ops = dict()
 
-    def setup(self, inputs : Sequence[Stream], outputs : Sequence[Stream], state: Mapping[str, Any]):
+    def setup(self, inputs: Sequence[Stream], outputs: Sequence[Stream], state: Mapping[str, Any]):
         &#39;&#39;&#39;
         Used to save references to streams and reset variables.
         Called once before the start of the execution in FilterNet.
-        
+
         Parameters:
             inputs, outputs : Sequence[Stream]
                 Ordered sequence containing the required input/output streams gained from the FilterNet.
             state : Mapping[str, Any]
                 Dictionary containing states to output.
         &#39;&#39;&#39;
-        self.__input = inputs[0]
-        self.__input_iter = iter(inputs[0])
-        self.__output = outputs[0]
+        # Call superclass setup
+        super().setup(inputs, outputs, state)
+        # Save the state instance
         self.__state = state
+        # Check if state name is already used, otherwise init a dict
         for stat_name in self.__ops.values():
             if state.get(stat_name, None) != None:
                 raise(ValueError(&#34;state &#39;{}&#39; uses duplicate name&#34;.format(stat_name)))
             state[stat_name] = dict()
 
-    def execute(self):
+    def _on_data(self, data, index):
         &#39;&#39;&#39;
         Pops a single piece of data, reads the fields in the `keys` init parameter, updates the state
         and outputs the data unmodified.
         &#39;&#39;&#39;
-        if self.__output.is_closed():
-            return
-        if self.__input_iter.has_next():
-            atom = next(self.__input_iter)
-            for op, stat_name in self.__ops.items():
-                op(atom, stat_name)
-            self.__output.append(atom)
-        # Check that we didn&#39;t just pop the last item
-        elif self.__input.is_closed():
-            self.__output.close()
+        # Update all of the operations
+        for op, stat_name in self.__ops.items():
+            op(data, stat_name)
+        # Output data unmodified
+        self._push_data(data)
 
     def calc_avg(self, state_name: str):
         &#39;&#39;&#39;
@@ -367,15 +357,15 @@ The keys for which to compute the stats.</p></div>
         self.__ops[self.__min] = state_name
         return self
 
-    def __sum(self, atom: Mapping, stat_name : str):
+    def __sum(self, atom: Mapping, stat_name: str):
         &#39;&#39;&#39;
         Update the sum state for the given keys.
         &#39;&#39;&#39;
         for k in self.__keys:
             if k in atom.keys():
-                self.__state[stat_name][k] = self.__state[stat_name].setdefault(k,0) + atom[k]
+                self.__state[stat_name][k] = self.__state[stat_name].setdefault(k, 0) + atom[k]
 
-    def __count(self, atom: Mapping, stat_name : str):
+    def __count(self, atom: Mapping, stat_name: str):
         &#39;&#39;&#39;
         Update the count state for the given keys.
         &#39;&#39;&#39;
@@ -383,7 +373,7 @@ The keys for which to compute the stats.</p></div>
             if k in atom.keys():
                 self.__state[stat_name][k] = self.__state[stat_name].setdefault(k, 0) + 1
 
-    def __max(self, atom: Mapping, stat_name : str):
+    def __max(self, atom: Mapping, stat_name: str):
         &#39;&#39;&#39;
         Update the max state for the given keys.
         &#39;&#39;&#39;
@@ -392,7 +382,7 @@ The keys for which to compute the stats.</p></div>
                 old_val = self.__state[stat_name].setdefault(k, float(&#39;-inf&#39;))
                 self.__state[stat_name][k] = max(old_val, atom[k])
 
-    def __min(self, atom: Mapping, stat_name : str):
+    def __min(self, atom: Mapping, stat_name: str):
         &#39;&#39;&#39;
         Update the min state for the given keys.
         &#39;&#39;&#39;
@@ -401,14 +391,15 @@ The keys for which to compute the stats.</p></div>
                 old_val = self.__state[stat_name].setdefault(k, float(&#39;inf&#39;))
                 self.__state[stat_name][k] = min(old_val, atom[k])
 
-    def __avg(self, atom : Mapping, stat_name : str):
+    def __avg(self, atom: Mapping, stat_name: str):
         &#39;&#39;&#39;
         Update the avg state for the given keys.
         &#39;&#39;&#39;
         for k in self.__keys:
             if k in atom.keys():
-                if(self.__state[self.__ops[self.__count]].setdefault(k,0) != 0):
-                    avg = self.__state[self.__ops[self.__sum]].setdefault(k,0) / self.__state[self.__ops[self.__count]][k]
+                if(self.__state[self.__ops[self.__count]].setdefault(k, 0) != 0):
+                    avg = self.__state[self.__ops[self.__sum]].setdefault(
+                        k, 0) / self.__state[self.__ops[self.__count]][k]
                     self.__state[stat_name][k] = avg</code></pre>
 </details>
 <h3>Ancestors</h3>
@@ -550,33 +541,6 @@ Naming for the key that will contain this state value.</p></div>
     return self</code></pre>
 </details>
 </dd>
-<dt id="otri.filtering.filters.statistics_filter.StatisticsFilter.execute"><code class="name flex">
-<span>def <span class="ident">execute</span></span>(<span>self)</span>
-</code></dt>
-<dd>
-<div class="desc"><p>Pops a single piece of data, reads the fields in the <code>keys</code> init parameter, updates the state
-and outputs the data unmodified.</p></div>
-<details class="source">
-<summary>
-<span>Expand source code</span>
-</summary>
-<pre><code class="python">def execute(self):
-    &#39;&#39;&#39;
-    Pops a single piece of data, reads the fields in the `keys` init parameter, updates the state
-    and outputs the data unmodified.
-    &#39;&#39;&#39;
-    if self.__output.is_closed():
-        return
-    if self.__input_iter.has_next():
-        atom = next(self.__input_iter)
-        for op, stat_name in self.__ops.items():
-            op(atom, stat_name)
-        self.__output.append(atom)
-    # Check that we didn&#39;t just pop the last item
-    elif self.__input.is_closed():
-        self.__output.close()</code></pre>
-</details>
-</dd>
 <dt id="otri.filtering.filters.statistics_filter.StatisticsFilter.setup"><code class="name flex">
 <span>def <span class="ident">setup</span></span>(<span>self, inputs: Sequence[<a title="otri.filtering.stream.Stream" href="../stream.html#otri.filtering.stream.Stream">Stream</a>], outputs: Sequence[<a title="otri.filtering.stream.Stream" href="../stream.html#otri.filtering.stream.Stream">Stream</a>], state: Mapping[str, Any])</span>
 </code></dt>
@@ -592,21 +556,22 @@ Dictionary containing states to output.</p></div>
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">def setup(self, inputs : Sequence[Stream], outputs : Sequence[Stream], state: Mapping[str, Any]):
+<pre><code class="python">def setup(self, inputs: Sequence[Stream], outputs: Sequence[Stream], state: Mapping[str, Any]):
     &#39;&#39;&#39;
     Used to save references to streams and reset variables.
     Called once before the start of the execution in FilterNet.
-    
+
     Parameters:
         inputs, outputs : Sequence[Stream]
             Ordered sequence containing the required input/output streams gained from the FilterNet.
         state : Mapping[str, Any]
             Dictionary containing states to output.
     &#39;&#39;&#39;
-    self.__input = inputs[0]
-    self.__input_iter = iter(inputs[0])
-    self.__output = outputs[0]
+    # Call superclass setup
+    super().setup(inputs, outputs, state)
+    # Save the state instance
     self.__state = state
+    # Check if state name is already used, otherwise init a dict
     for stat_name in self.__ops.values():
         if state.get(stat_name, None) != None:
             raise(ValueError(&#34;state &#39;{}&#39; uses duplicate name&#34;.format(stat_name)))
@@ -618,8 +583,9 @@ Dictionary containing states to output.</p></div>
 <ul class="hlist">
 <li><code><b><a title="otri.filtering.filter.Filter" href="../filter.html#otri.filtering.filter.Filter">Filter</a></b></code>:
 <ul class="hlist">
-<li><code><a title="otri.filtering.filter.Filter.get_inputs" href="../filter.html#otri.filtering.filter.Filter.get_inputs">get_inputs</a></code></li>
-<li><code><a title="otri.filtering.filter.Filter.get_outputs" href="../filter.html#otri.filtering.filter.Filter.get_outputs">get_outputs</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.execute" href="../filter.html#otri.filtering.filter.Filter.execute">execute</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.get_input_names" href="../filter.html#otri.filtering.filter.Filter.get_input_names">get_input_names</a></code></li>
+<li><code><a title="otri.filtering.filter.Filter.get_output_names" href="../filter.html#otri.filtering.filter.Filter.get_output_names">get_output_names</a></code></li>
 </ul>
 </li>
 </ul>
@@ -648,7 +614,6 @@ Dictionary containing states to output.</p></div>
 <li><code><a title="otri.filtering.filters.statistics_filter.StatisticsFilter.calc_max" href="#otri.filtering.filters.statistics_filter.StatisticsFilter.calc_max">calc_max</a></code></li>
 <li><code><a title="otri.filtering.filters.statistics_filter.StatisticsFilter.calc_min" href="#otri.filtering.filters.statistics_filter.StatisticsFilter.calc_min">calc_min</a></code></li>
 <li><code><a title="otri.filtering.filters.statistics_filter.StatisticsFilter.calc_sum" href="#otri.filtering.filters.statistics_filter.StatisticsFilter.calc_sum">calc_sum</a></code></li>
-<li><code><a title="otri.filtering.filters.statistics_filter.StatisticsFilter.execute" href="#otri.filtering.filters.statistics_filter.StatisticsFilter.execute">execute</a></code></li>
 <li><code><a title="otri.filtering.filters.statistics_filter.StatisticsFilter.setup" href="#otri.filtering.filters.statistics_filter.StatisticsFilter.setup">setup</a></code></li>
 </ul>
 </li>

--- a/doc/otri/importer/data_importer.html
+++ b/doc/otri/importer/data_importer.html
@@ -29,6 +29,7 @@
 <pre><code class="python">from ..database.database_adapter import DatabaseAdapter, DatabaseData
 from ..downloader.timeseries_downloader import META_INTERVAL_KEY, META_PROVIDER_KEY, META_TICKER_KEY, ATOMS_KEY, METADATA_KEY
 from typing import Mapping, Sequence
+from ..utils import logger as log
 from pathlib import Path
 import json
 
@@ -80,7 +81,7 @@ class DataImporter:
             try:
                 json_file_contents = json.load(json_file)
             except (Exception) as error:
-                print(&#34;Unable to load file {}: {}&#34;.format(json_file_path, error))
+                log.e(&#34;Unable to load file {}: {}&#34;.format(json_file_path, error))
         self.from_contents(json_file_contents)
 
 
@@ -185,7 +186,7 @@ Adapter for the database where to store the imported data</p></div>
             try:
                 json_file_contents = json.load(json_file)
             except (Exception) as error:
-                print(&#34;Unable to load file {}: {}&#34;.format(json_file_path, error))
+                log.e(&#34;Unable to load file {}: {}&#34;.format(json_file_path, error))
         self.from_contents(json_file_contents)</code></pre>
 </details>
 <h3>Subclasses</h3>
@@ -241,7 +242,7 @@ The path of the json file to import.</p></div>
         try:
             json_file_contents = json.load(json_file)
         except (Exception) as error:
-            print(&#34;Unable to load file {}: {}&#34;.format(json_file_path, error))
+            log.e(&#34;Unable to load file {}: {}&#34;.format(json_file_path, error))
     self.from_contents(json_file_contents)</code></pre>
 </details>
 </dd>

--- a/doc/otri/utils/index.html
+++ b/doc/otri/utils/index.html
@@ -34,6 +34,11 @@
 <dd>
 <div class="desc"></div>
 </dd>
+<dt><code class="name"><a title="otri.utils.logger" href="logger.html">otri.utils.logger</a></code></dt>
+<dd>
+<div class="desc"><p>Module to log errors and warnings on a LOG.txt file.
+Everything from verbose up (levels 1-4) gets printed in the console too.</p></div>
+</dd>
 <dt><code class="name"><a title="otri.utils.time_handler" href="time_handler.html">otri.utils.time_handler</a></code></dt>
 <dd>
 <div class="desc"></div>
@@ -62,6 +67,7 @@
 <ul>
 <li><code><a title="otri.utils.config" href="config.html">otri.utils.config</a></code></li>
 <li><code><a title="otri.utils.key_handler" href="key_handler.html">otri.utils.key_handler</a></code></li>
+<li><code><a title="otri.utils.logger" href="logger.html">otri.utils.logger</a></code></li>
 <li><code><a title="otri.utils.time_handler" href="time_handler.html">otri.utils.time_handler</a></code></li>
 </ul>
 </li>

--- a/doc/otri/utils/logger.html
+++ b/doc/otri/utils/logger.html
@@ -1,0 +1,371 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.8.3" />
+<title>otri.utils.logger API documentation</title>
+<meta name="description" content="Module to log errors and warnings on a LOG.txt file.
+Everything from verbose up (levels 1-4) gets printed in the console too." />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/highlight.min.js" integrity="sha256-eOgo0OtLL4cdq7RdwRUiGKLX9XsIJ7nGhWEKbohmVAQ=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>otri.utils.logger</code></h1>
+</header>
+<section id="section-intro">
+<p>Module to log errors and warnings on a LOG.txt file.
+Everything from verbose up (levels 1-4) gets printed in the console too.</p>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">&#34;&#34;&#34;
+Module to log errors and warnings on a LOG.txt file.
+Everything from verbose up (levels 1-4) gets printed in the console too.
+&#34;&#34;&#34;
+__version__ = &#34;1.0&#34;
+__all__ = [&#34;v&#34;, &#34;d&#34;, &#34;i&#34;, &#34;w&#34;, &#34;e&#34;]
+__author__ = &#34;Luca Crema &lt;lc.crema@hotmail.com&gt;&#34;
+
+from typing import Tuple
+from datetime import datetime
+from termcolor import colored
+from pathlib import Path
+
+import os
+import sys
+
+
+def __caller_info() -&gt; Tuple[str, int]:
+    &#39;&#39;&#39;
+    Gets some information about the module caller.
+    Returns:
+        The filename of the caller.
+        The line number of the call.
+    &#39;&#39;&#39;
+    # Get caller class and method
+    frame = sys._getframe(3)
+    # Get rid of absolute path
+    filename = os.path.splitext(os.path.basename(frame.f_code.co_filename))[0]
+    return filename, frame.f_lineno
+
+
+def __make_file():
+    &#39;&#39;&#39;
+    Ensures LOG_DIR exists.
+    Returns:
+        The Path to the default log file.
+    &#39;&#39;&#39;
+    LOG_DIR.mkdir(exist_ok=True)
+    timestamp = datetime.now().strftime(&#34;%Y_%m_%d_%H_%M_%S_%f&#34;)[:-3]
+    return Path(LOG_DIR, &#34;logger_{}.txt&#34;.format(timestamp))
+
+
+def __time():
+    &#39;&#39;&#39;
+    Returns:
+        A formatted timestamp for logging.
+    &#39;&#39;&#39;
+    time = datetime.now()
+    return time.strftime(&#34;%Y-%m-%d %H:%M:%S.%f&#34;)[:-3]
+
+
+# Log files subdirectory.
+LOG_DIR = Path(&#34;log/&#34;)
+# File will always be called &#34;logger_timestamp&#34; by default.
+LOG_FILE = __make_file()
+
+NAMES = (
+    &#34;VERBOSE&#34;,
+    &#34;DEBUG&#34;,
+    &#34;INFO&#34;,
+    &#34;WARNING&#34;,
+    &#34;ERROR&#34;
+)
+
+COLORS = (
+    &#34;grey&#34;,
+    &#34;cyan&#34;,
+    &#34;green&#34;,
+    &#34;yellow&#34;,
+    &#34;red&#34;
+)
+
+min_console_priority = -1
+
+
+
+def v(msg: str, log_file: Path = LOG_FILE):
+    &#39;&#39;&#39;
+    Logs a VERBOSE message.
+    Parameters:
+        msg : str
+            Content of the message to log.
+        log_file : Path
+            The log file where the output should be written.
+    &#39;&#39;&#39;
+    _log(0, msg, log_file)
+
+
+def d(msg: str, log_file: Path = LOG_FILE):
+    &#39;&#39;&#39;
+    Logs a DEBUG message.
+    Parameters:
+        msg : str
+            Content of the message to log.
+
+        log_file : Path
+            The log file where the output should be written.
+    &#39;&#39;&#39;
+    _log(1, msg, log_file)
+
+
+def i(msg: str, log_file: Path = LOG_FILE):
+    &#39;&#39;&#39;
+    Logs a INFO message.
+    Parameters:
+        msg : str
+            Content of the message to log.
+        log_file : Path
+            The log file where the output should be written.
+    &#39;&#39;&#39;
+    _log(2, msg, log_file)
+
+
+def w(msg: str, log_file: Path = LOG_FILE):
+    &#39;&#39;&#39;
+    Logs a WARNING message.
+    Parameters:
+        msg : str
+            Content of the message to log.
+        log_file : Path
+            The log file where the output should be written.
+    &#39;&#39;&#39;
+    _log(3, msg, log_file)
+
+
+def e(msg: str, log_file: Path = LOG_FILE):
+    &#39;&#39;&#39;
+    Logs an ERROR message.
+    Parameters:
+        msg : str
+            Content of the message to log.
+        log_file : Path
+            The log file where the output should be written.
+    &#39;&#39;&#39;
+    _log(4, msg, log_file)
+
+
+def _log(priority: int, msg: str, log_file: Path):
+    &#39;&#39;&#39;
+    Logs the message into the log file keeping track of the datetime and priority level.
+
+    Parameters:
+        priority : int
+            Level of priority, must be within 0 and 4 where 0 is a normal message and 4 is a critical error.
+        msg : str
+            Content of the message to log.
+        log_file : Path
+            The log file to which the output should be sent.
+    &#39;&#39;&#39;
+    # Get current datetime
+    time = __time()
+    # Translate priority into a word
+    priority_name = NAMES[priority]
+    # Get caller data
+    caller, lineno = __caller_info()
+    # Build the line
+    console_line = colored(
+        &#34;{} {}:{} - {}&#34;.format(priority_name, caller, lineno, msg),
+        COLORS[priority]
+    )
+    file_line = &#34;{} {} {}:{} - {}&#34;.format(priority_name, time, caller, lineno, msg)
+    # Write on file
+    with log_file.open(&#34;a&#34;) as f:
+        f.write(file_line + &#34;\n&#34;)
+    # Print on console if needed
+    if(priority &gt;= 1):
+        print(console_line)</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-functions">Functions</h2>
+<dl>
+<dt id="otri.utils.logger.d"><code class="name flex">
+<span>def <span class="ident">d</span></span>(<span>msg: str, log_file: pathlib.Path = WindowsPath('log/logger_2020_07_20_18_50_31_294.txt'))</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Logs a DEBUG message.</p>
+<h2 id="parameters">Parameters</h2>
+<p>msg : str
+Content of the message to log.</p>
+<p>log_file : Path
+The log file where the output should be written.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def d(msg: str, log_file: Path = LOG_FILE):
+    &#39;&#39;&#39;
+    Logs a DEBUG message.
+    Parameters:
+        msg : str
+            Content of the message to log.
+
+        log_file : Path
+            The log file where the output should be written.
+    &#39;&#39;&#39;
+    _log(1, msg, log_file)</code></pre>
+</details>
+</dd>
+<dt id="otri.utils.logger.e"><code class="name flex">
+<span>def <span class="ident">e</span></span>(<span>msg: str, log_file: pathlib.Path = WindowsPath('log/logger_2020_07_20_18_50_31_294.txt'))</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Logs an ERROR message.</p>
+<h2 id="parameters">Parameters</h2>
+<p>msg : str
+Content of the message to log.
+log_file : Path
+The log file where the output should be written.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def e(msg: str, log_file: Path = LOG_FILE):
+    &#39;&#39;&#39;
+    Logs an ERROR message.
+    Parameters:
+        msg : str
+            Content of the message to log.
+        log_file : Path
+            The log file where the output should be written.
+    &#39;&#39;&#39;
+    _log(4, msg, log_file)</code></pre>
+</details>
+</dd>
+<dt id="otri.utils.logger.i"><code class="name flex">
+<span>def <span class="ident">i</span></span>(<span>msg: str, log_file: pathlib.Path = WindowsPath('log/logger_2020_07_20_18_50_31_294.txt'))</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Logs a INFO message.</p>
+<h2 id="parameters">Parameters</h2>
+<p>msg : str
+Content of the message to log.
+log_file : Path
+The log file where the output should be written.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def i(msg: str, log_file: Path = LOG_FILE):
+    &#39;&#39;&#39;
+    Logs a INFO message.
+    Parameters:
+        msg : str
+            Content of the message to log.
+        log_file : Path
+            The log file where the output should be written.
+    &#39;&#39;&#39;
+    _log(2, msg, log_file)</code></pre>
+</details>
+</dd>
+<dt id="otri.utils.logger.v"><code class="name flex">
+<span>def <span class="ident">v</span></span>(<span>msg: str, log_file: pathlib.Path = WindowsPath('log/logger_2020_07_20_18_50_31_294.txt'))</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Logs a VERBOSE message.</p>
+<h2 id="parameters">Parameters</h2>
+<p>msg : str
+Content of the message to log.
+log_file : Path
+The log file where the output should be written.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def v(msg: str, log_file: Path = LOG_FILE):
+    &#39;&#39;&#39;
+    Logs a VERBOSE message.
+    Parameters:
+        msg : str
+            Content of the message to log.
+        log_file : Path
+            The log file where the output should be written.
+    &#39;&#39;&#39;
+    _log(0, msg, log_file)</code></pre>
+</details>
+</dd>
+<dt id="otri.utils.logger.w"><code class="name flex">
+<span>def <span class="ident">w</span></span>(<span>msg: str, log_file: pathlib.Path = WindowsPath('log/logger_2020_07_20_18_50_31_294.txt'))</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Logs a WARNING message.</p>
+<h2 id="parameters">Parameters</h2>
+<p>msg : str
+Content of the message to log.
+log_file : Path
+The log file where the output should be written.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def w(msg: str, log_file: Path = LOG_FILE):
+    &#39;&#39;&#39;
+    Logs a WARNING message.
+    Parameters:
+        msg : str
+            Content of the message to log.
+        log_file : Path
+            The log file where the output should be written.
+    &#39;&#39;&#39;
+    _log(3, msg, log_file)</code></pre>
+</details>
+</dd>
+</dl>
+</section>
+<section>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="otri.utils" href="index.html">otri.utils</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-functions">Functions</a></h3>
+<ul class="">
+<li><code><a title="otri.utils.logger.d" href="#otri.utils.logger.d">d</a></code></li>
+<li><code><a title="otri.utils.logger.e" href="#otri.utils.logger.e">e</a></code></li>
+<li><code><a title="otri.utils.logger.i" href="#otri.utils.logger.i">i</a></code></li>
+<li><code><a title="otri.utils.logger.v" href="#otri.utils.logger.v">v</a></code></li>
+<li><code><a title="otri.utils.logger.w" href="#otri.utils.logger.w">w</a></code></li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.8.3</a>.</p>
+</footer>
+</body>
+</html>

--- a/doc/otri/utils/logger.html
+++ b/doc/otri/utils/logger.html
@@ -206,7 +206,7 @@ def _log(priority: int, msg: str, log_file: Path):
 <h2 class="section-title" id="header-functions">Functions</h2>
 <dl>
 <dt id="otri.utils.logger.d"><code class="name flex">
-<span>def <span class="ident">d</span></span>(<span>msg: str, log_file: pathlib.Path = WindowsPath('log/logger_2020_07_20_18_50_31_294.txt'))</span>
+<span>def <span class="ident">d</span></span>(<span>msg: str, log_file: pathlib.Path = WindowsPath('log/logger_2020_07_20_19_05_31_768.txt'))</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Logs a DEBUG message.</p>
@@ -233,7 +233,7 @@ The log file where the output should be written.</p></div>
 </details>
 </dd>
 <dt id="otri.utils.logger.e"><code class="name flex">
-<span>def <span class="ident">e</span></span>(<span>msg: str, log_file: pathlib.Path = WindowsPath('log/logger_2020_07_20_18_50_31_294.txt'))</span>
+<span>def <span class="ident">e</span></span>(<span>msg: str, log_file: pathlib.Path = WindowsPath('log/logger_2020_07_20_19_05_31_768.txt'))</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Logs an ERROR message.</p>
@@ -259,7 +259,7 @@ The log file where the output should be written.</p></div>
 </details>
 </dd>
 <dt id="otri.utils.logger.i"><code class="name flex">
-<span>def <span class="ident">i</span></span>(<span>msg: str, log_file: pathlib.Path = WindowsPath('log/logger_2020_07_20_18_50_31_294.txt'))</span>
+<span>def <span class="ident">i</span></span>(<span>msg: str, log_file: pathlib.Path = WindowsPath('log/logger_2020_07_20_19_05_31_768.txt'))</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Logs a INFO message.</p>
@@ -285,7 +285,7 @@ The log file where the output should be written.</p></div>
 </details>
 </dd>
 <dt id="otri.utils.logger.v"><code class="name flex">
-<span>def <span class="ident">v</span></span>(<span>msg: str, log_file: pathlib.Path = WindowsPath('log/logger_2020_07_20_18_50_31_294.txt'))</span>
+<span>def <span class="ident">v</span></span>(<span>msg: str, log_file: pathlib.Path = WindowsPath('log/logger_2020_07_20_19_05_31_768.txt'))</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Logs a VERBOSE message.</p>
@@ -311,7 +311,7 @@ The log file where the output should be written.</p></div>
 </details>
 </dd>
 <dt id="otri.utils.logger.w"><code class="name flex">
-<span>def <span class="ident">w</span></span>(<span>msg: str, log_file: pathlib.Path = WindowsPath('log/logger_2020_07_20_18_50_31_294.txt'))</span>
+<span>def <span class="ident">w</span></span>(<span>msg: str, log_file: pathlib.Path = WindowsPath('log/logger_2020_07_20_19_05_31_768.txt'))</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Logs a WARNING message.</p>

--- a/doc/otri/utils/time_handler.html
+++ b/doc/otri/utils/time_handler.html
@@ -26,13 +26,26 @@
 <summary>
 <span>Expand source code</span>
 </summary>
-<pre><code class="python">from datetime import datetime
+<pre><code class="python">from datetime import datetime, time, timedelta
 
 def str_to_datetime(string : str) -&gt; datetime:
     return datetime.strptime(string, &#34;%Y-%m-%d %H:%M:%S.%f&#34;)
 
 def datetime_to_str(dt : datetime) -&gt; str:
-    return dt.strftime(&#34;%Y-%m-%d %H:%M:%S.%f&#34;)[:-3]</code></pre>
+    return dt.strftime(&#34;%Y-%m-%d %H:%M:%S.%f&#34;)[:-3]
+
+def datetime_to_epoch(dt : datetime) -&gt; int:
+    return int((dt - datetime(1970,1,1)).total_seconds())
+
+def datetime_to_time(dt : datetime) -&gt; time:
+    &#39;&#39;&#39;
+    Removes year month and year from a datetime.
+    &#39;&#39;&#39;
+    return time(hour=dt.hour, minute=dt.minute, second=dt.second, microsecond=dt.microsecond)
+
+def sum_time(t : time, td : timedelta) -&gt; time:
+    tmp_dt = datetime.combine(datetime(1,1,1), t) + td
+    return tmp_dt.time()</code></pre>
 </details>
 </section>
 <section>
@@ -42,6 +55,19 @@ def datetime_to_str(dt : datetime) -&gt; str:
 <section>
 <h2 class="section-title" id="header-functions">Functions</h2>
 <dl>
+<dt id="otri.utils.time_handler.datetime_to_epoch"><code class="name flex">
+<span>def <span class="ident">datetime_to_epoch</span></span>(<span>dt: datetime.datetime) ‑> int</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def datetime_to_epoch(dt : datetime) -&gt; int:
+    return int((dt - datetime(1970,1,1)).total_seconds())</code></pre>
+</details>
+</dd>
 <dt id="otri.utils.time_handler.datetime_to_str"><code class="name flex">
 <span>def <span class="ident">datetime_to_str</span></span>(<span>dt: datetime.datetime) ‑> str</span>
 </code></dt>
@@ -55,6 +81,22 @@ def datetime_to_str(dt : datetime) -&gt; str:
     return dt.strftime(&#34;%Y-%m-%d %H:%M:%S.%f&#34;)[:-3]</code></pre>
 </details>
 </dd>
+<dt id="otri.utils.time_handler.datetime_to_time"><code class="name flex">
+<span>def <span class="ident">datetime_to_time</span></span>(<span>dt: datetime.datetime) ‑> datetime.time</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Removes year month and year from a datetime.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def datetime_to_time(dt : datetime) -&gt; time:
+    &#39;&#39;&#39;
+    Removes year month and year from a datetime.
+    &#39;&#39;&#39;
+    return time(hour=dt.hour, minute=dt.minute, second=dt.second, microsecond=dt.microsecond)</code></pre>
+</details>
+</dd>
 <dt id="otri.utils.time_handler.str_to_datetime"><code class="name flex">
 <span>def <span class="ident">str_to_datetime</span></span>(<span>string: str) ‑> datetime.datetime</span>
 </code></dt>
@@ -66,6 +108,20 @@ def datetime_to_str(dt : datetime) -&gt; str:
 </summary>
 <pre><code class="python">def str_to_datetime(string : str) -&gt; datetime:
     return datetime.strptime(string, &#34;%Y-%m-%d %H:%M:%S.%f&#34;)</code></pre>
+</details>
+</dd>
+<dt id="otri.utils.time_handler.sum_time"><code class="name flex">
+<span>def <span class="ident">sum_time</span></span>(<span>t: datetime.time, td: datetime.timedelta) ‑> datetime.time</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def sum_time(t : time, td : timedelta) -&gt; time:
+    tmp_dt = datetime.combine(datetime(1,1,1), t) + td
+    return tmp_dt.time()</code></pre>
 </details>
 </dd>
 </dl>
@@ -86,8 +142,11 @@ def datetime_to_str(dt : datetime) -&gt; str:
 </li>
 <li><h3><a href="#header-functions">Functions</a></h3>
 <ul class="">
+<li><code><a title="otri.utils.time_handler.datetime_to_epoch" href="#otri.utils.time_handler.datetime_to_epoch">datetime_to_epoch</a></code></li>
 <li><code><a title="otri.utils.time_handler.datetime_to_str" href="#otri.utils.time_handler.datetime_to_str">datetime_to_str</a></code></li>
+<li><code><a title="otri.utils.time_handler.datetime_to_time" href="#otri.utils.time_handler.datetime_to_time">datetime_to_time</a></code></li>
 <li><code><a title="otri.utils.time_handler.str_to_datetime" href="#otri.utils.time_handler.str_to_datetime">str_to_datetime</a></code></li>
+<li><code><a title="otri.utils.time_handler.sum_time" href="#otri.utils.time_handler.sum_time">sum_time</a></code></li>
 </ul>
 </li>
 </ul>

--- a/otri/filtering/filter_net.py
+++ b/otri/filtering/filter_net.py
@@ -55,7 +55,7 @@ class FilterNet:
                         self.__get_streams_by_names(f.get_output_names()), self.state_dict)
 
         # Execute phase
-        layer_index = 0;
+        layer_index = 0
         layer = None
         while(True):
             layer = self.__layers[layer_index]
@@ -70,7 +70,7 @@ class FilterNet:
                         if f._has_outputted:
                             on_data_output()
                 if self.__is_all_finished():
-                    break;
+                    break
             # Ask the policy for the new layer index
             layer_index += layer.call_policy()
             if(layer_index >= len(self.__layers)):

--- a/otri/filtering/filters/interpolation_filter.py
+++ b/otri/filtering/filters/interpolation_filter.py
@@ -51,15 +51,6 @@ class InterpolationFilter(Filter):
             for atom in output_atoms:
                 self._push_data(atom)
 
-    def _on_inputs_closed(self):
-        '''
-        Pushes out the atom in the buffer and closes the outputs
-        '''
-        if(self.atom_buffer != None):
-            self._push_data(self.atom_buffer)
-            self.atom_buffer = None
-        super()._on_inputs_closed()
-
     def _create_atoms(self, B: dict) -> Sequence[dict]:
         raise NotImplementedError()
 

--- a/otri/filtering/filters/interpolation_filter.py
+++ b/otri/filtering/filters/interpolation_filter.py
@@ -1,14 +1,8 @@
 from ..filter import Filter, Stream, Sequence, Any, Mapping
 from typing import Collection
-from datetime import timedelta
+from datetime import timedelta, datetime, time, date
 from ...utils import time_handler as th
-
-TIMEDELTA_DICT: dict = {
-    "seconds": timedelta(seconds=1),
-    "minutes": timedelta(minutes=1),
-    "hours": timedelta(hours=1),
-    "days": timedelta(days=1)
-}
+from numpy import interp
 
 
 class InterpolationFilter(Filter):
@@ -19,10 +13,10 @@ class InterpolationFilter(Filter):
     Inputs:
         Oredered by datetime atoms.
     Outputs:
-        Atoms interpolated for the given target interval
+        Atoms interpolated at the desired frequency.
     '''
 
-    def __init__(self, inputs: str, outputs: str, keys_to_interp: Collection[str], target_interval: str = "minutes"):
+    def __init__(self, inputs: str, outputs: str, keys_to_interp: Collection[str]):
         '''
         Parameters:
             inputs : str
@@ -31,9 +25,10 @@ class InterpolationFilter(Filter):
                 Output stream name.
             keys_to_interp : Collection[str]
                 Collection of keys to update when calculating interpolation. Will be the only keys of the atoms (with datetime too).
-            target_interval : str
-                The maximum interval between successive atoms.
-                Could be "seconds", "minutes", "hours", "days".
+            target_gap_seconds : str
+                The target gap between atoms in seconds.
+            working_hours : tuple(start, end)
+                Tuple containing datetime for start hour minutes and seconds and end time. Values will be calculated inside these working hours only.
         '''
         super().__init__(
             inputs=[inputs],
@@ -41,9 +36,7 @@ class InterpolationFilter(Filter):
             input_count=1,
             output_count=1
         )
-        self.target_interval = target_interval
         self.keys_to_interp = keys_to_interp
-        self.timeunit = InterpolationFilter.__timedelta_from_interval(interval=target_interval)
         self.atom_buffer = None
 
     def _on_data(self, data, index):
@@ -54,7 +47,7 @@ class InterpolationFilter(Filter):
             # Do nothing, just save the atom for the next iteration
             self.atom_buffer = data
         else:
-            output_atoms = self.__create_missing_atoms(data)
+            output_atoms = self._create_atoms(data)
             for atom in output_atoms:
                 self._push_data(atom)
 
@@ -65,48 +58,95 @@ class InterpolationFilter(Filter):
         if(self.atom_buffer != None):
             self._push_data(self.atom_buffer)
             self.atom_buffer = None
-        self._get_output().close()
+        super()._on_inputs_closed()
 
-    def __create_missing_atoms(self, atom: dict) -> Any:
-        '''
-        Pushes into the output stream the current self.atom_buffer and all the interpolated atoms between that and the give atom.
-        '''
-        atom1_datetime = th.str_to_datetime(self.atom_buffer['datetime'])
-        atom2_datetime = th.str_to_datetime(atom['datetime'])
-        atom12_dt_diff = (atom2_datetime - atom1_datetime).total_seconds()
-        new_atom_datetime = atom1_datetime + self.timeunit
-        output_atoms = list()
-        # Place the current atom_buffer into the output
-        output_atoms.append(self.atom_buffer)
+    def _create_atoms(self, B: dict) -> Sequence[dict]:
+        raise NotImplementedError()
 
-        while(new_atom_datetime < atom2_datetime):
-            new_atom = {}
-            new_atom['datetime'] = th.datetime_to_str(new_atom_datetime)
-            progress = (new_atom_datetime -
-                        atom1_datetime).total_seconds() / atom12_dt_diff
+
+class IntradayInterpolationFilter(InterpolationFilter):
+    '''
+    Interpolates value between two stream atoms if their time difference is greater than a given maximum interval.
+    The resulting atoms will have given values interpolated.\n
+
+    Inputs:\n
+        Oredered by datetime atoms.\n
+    Outputs:\n
+        Atoms interpolated at the desired frequency.\n
+    '''
+
+    def __init__(self, inputs: str, outputs: str, keys_to_interp: Collection[str], target_gap_seconds: int = 60, working_hours: tuple = (time(hour=8), time(hour=20))):
+        '''
+        Parameters:\n
+            inputs : str\n
+                Input stream name.\n
+            outputs : str\n
+                Output stream name.\n
+            keys_to_interp : Collection[str]\n
+                Collection of keys to update when calculating interpolation. Will be the only keys of the atoms (with datetime too).\n
+            target_gap_seconds : str\n
+                The target gap between atoms in seconds.\n
+            working_hours : tuple(start, end)\n
+                Tuple containing datetime.time for start hour minutes and seconds and end time. Values will be calculated inside these working hours only.
+                The start time must be earlier than end time by at least one target_gap_seconds seconds\n
+        '''
+        super().__init__(
+            inputs=inputs,
+            outputs=outputs,
+            keys_to_interp=keys_to_interp
+        )
+        self.__gap_datetime = timedelta(seconds=target_gap_seconds)
+        self.__working_hours = working_hours
+        # Iterates through time of the day and resets on a new day
+        self.__instant_iterator = working_hours[0]
+
+    def _create_atoms(self, B: dict) -> Any:
+        '''
+        Pushes into the output stream the current self.atom_buffer and all the interpolated atoms between that and the give atom.\n
+        '''
+        A_datetime = th.str_to_datetime(self.atom_buffer['datetime'])
+        B_datetime = th.str_to_datetime(B['datetime'])
+        A_epoch = th.datetime_to_epoch(A_datetime)
+        B_epoch = th.datetime_to_epoch(B_datetime)
+
+        interp_instants = []
+
+        # Interpolate from the starting hour for the first atom
+        if not hasattr(self, "cur_day"):
+            self.cur_day = A_datetime.date()
+            self.__instant_iterator = self.__working_hours[0]
+
+        while(self.__instant_iterator <= th.datetime_to_time(A_datetime) and self.__instant_iterator <= self.__working_hours[1]):
+            interp_instants.append(th.datetime_to_epoch(datetime.combine(A_datetime.date(), self.__instant_iterator)))
+            self.__instant_iterator = th.sum_time(self.__instant_iterator, self.__gap_datetime)
+        
+        # Interpolate between the two atoms
+        while(self.cur_day < B_datetime.date()):
+            while(self.__instant_iterator <= self.__working_hours[1]):
+                interp_instants.append(th.datetime_to_epoch(datetime.combine(self.cur_day, self.__instant_iterator)))
+                self.__instant_iterator = th.sum_time(self.__instant_iterator, self.__gap_datetime)
+            self.cur_day += timedelta(days=1)
+            self.__instant_iterator = self.__working_hours[0]
+
+        # Reached the B day
+        while(self.__instant_iterator <= th.datetime_to_time(B_datetime) and self.__instant_iterator <= self.__working_hours[1]):
+            interp_instants.append(th.datetime_to_epoch(datetime.combine(self.cur_day, self.__instant_iterator)))
+            self.__instant_iterator = th.sum_time(self.__instant_iterator, self.__gap_datetime)
+            
+        output_atoms = []
+        interp_values = {}
+        for key in self.keys_to_interp:
+            interp_values[key] = interp(
+                x = interp_instants,
+                xp = [A_epoch, B_epoch],
+                fp = [float(self.atom_buffer[key]), float(B[key])]
+            )
+        
+        for i in range(len(interp_instants)):
+            atom = {}
+            atom['datetime'] = th.datetime_to_str(datetime.utcfromtimestamp(interp_instants[i]))
             for key in self.keys_to_interp:
-                new_atom[key] = self.atom_buffer[key] + (atom[key] - self.atom_buffer[key]) * progress
-            output_atoms.append(new_atom)
+                atom[key] = interp_values[key][i]
+            output_atoms.append(atom)
 
-            new_atom_datetime = new_atom_datetime + self.timeunit
-        self.atom_buffer = atom
         return output_atoms
-
-    @staticmethod
-    def __timedelta_from_interval(interval: str) -> timedelta:
-        '''
-        Returns the unit timedelta given the interval.
-
-        Parameters:
-            interval : str
-                The interval to use to calculate the number of datetimes between the two give atoms'.
-                Could be "seconds", "minutes", "hours", "days".
-        Returns:
-            datetime.timedelta
-        Raises:
-            ValueError if the interval is not supported
-        '''
-        value = TIMEDELTA_DICT.get(interval, None)
-        if(value == None):
-            raise ValueError("Interval {} is not supported".format(interval))
-        return value

--- a/otri/utils/time_handler.py
+++ b/otri/utils/time_handler.py
@@ -1,7 +1,20 @@
-from datetime import datetime
+from datetime import datetime, time, timedelta
 
 def str_to_datetime(string : str) -> datetime:
     return datetime.strptime(string, "%Y-%m-%d %H:%M:%S.%f")
 
 def datetime_to_str(dt : datetime) -> str:
     return dt.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+
+def datetime_to_epoch(dt : datetime) -> int:
+    return int((dt - datetime(1970,1,1)).total_seconds())
+
+def datetime_to_time(dt : datetime) -> time:
+    '''
+    Removes year month and year from a datetime.
+    '''
+    return time(hour=dt.hour, minute=dt.minute, second=dt.second, microsecond=dt.microsecond)
+
+def sum_time(t : time, td : timedelta) -> time:
+    tmp_dt = datetime.combine(datetime(1,1,1), t) + td
+    return tmp_dt.time()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ psycopg2==2.8.5
 xmltodict==0.12.0
 matplot==0.1.9
 matplotlib==3.2.1
-pytest==5.4.1
-pytest-cov==2.8.1
 termcolor==1.1.0
 progress==1.5
+numpy==1.19.0

--- a/test/filtering/filters/interpolation_filter_test.py
+++ b/test/filtering/filters/interpolation_filter_test.py
@@ -1,0 +1,74 @@
+import unittest
+from otri.filtering.stream import Stream
+from otri.filtering.filters.interpolation_filter import IntradayInterpolationFilter
+
+ATOMS = [
+    {
+        "ticker":"AAPL",
+        "close":"100",
+        "datetime":"2020-04-28 19:58:00.000"
+    },
+    {
+        "ticker":"AAPL",
+        "close":"110",
+        "datetime":"2020-04-28 20:05:00.000"
+    },
+    {
+        "ticker":"AAPL",
+        "close":"120",
+        "datetime":"2020-04-28 21:00:00.000"
+    },
+    {
+        "ticker":"AAPL",
+        "close":"125",
+        "datetime":"2020-04-28 06:50:00.000"
+    },
+    {
+        "ticker":"AAPL",
+        "close":"130",
+        "datetime":"2020-04-29 08:01:00.000"
+    }
+]
+
+class IntradayInterpolationFilterTest(unittest.TestCase):
+
+    def setUp(self):
+        self.inputs = [Stream(ATOMS, is_closed=True)]
+        self.outputs = [Stream()]
+        self.f = IntradayInterpolationFilter("in","out",["close"], 60)
+        self.f.setup(self.inputs, self.outputs, None)
+
+    def test_single_exec_no_output(self):
+        # Assert no output is 
+        self.f.execute()
+        self.assertEqual(0, len(self.outputs[0]))
+
+    def test_starts_from_moring(self):
+        # First atom should be at the starting working hour
+        self.f.execute()
+        self.f.execute()
+        self.assertEqual("2020-04-28 08:00:00.000", self.outputs[0][0]['datetime'])
+
+    def test_stops_at_night(self):
+        # Last atom is at the end of the day
+        self.f.execute()
+        self.f.execute()
+        self.assertEqual("2020-04-28 20:00:00.000", self.outputs[0][len(self.outputs[0]) - 1]['datetime'])
+
+    def test_avoid_night(self):
+        self.f.execute()
+        self.f.execute()
+        before_len = len(self.outputs[0])
+        # Having another atom later at night should avoid outputting other atoms
+        self.f.execute()
+        after_len = len(self.outputs[0])
+        self.assertEqual(before_len, after_len)
+
+    def test_avoid_early_morning(self):
+        self.f.execute()
+        self.f.execute()
+        self.f.execute()
+        before_len = len(self.outputs[0])
+        self.f.execute()
+        after_len = len(self.outputs[0])
+        self.assertEqual(before_len, after_len)


### PR DESCRIPTION
## Premise
Old interpolation filter had a few flaws we discussed a long time ago in [this Trello card](https://trello.com/c/DCBf1g2p)

## Features

#### refactor(interpolation_filter):
+ The filter used to make sure that no longer than X seconds passed between atoms instead of deciding a frequency and forcing atoms to be interpolated on that frequency, well now it deletes atoms out of that frequency.
+ It filters atoms by working hours, it's by default 8.00-20.00 but it can be easily changed.
+ As suggested by @ricdezen like three months ago it's now using NumPy to calculate linear interpolation.

#### created(intraday interpolation filter):
I didn't want to handle daily or weekly interpolation, so instead of doing it in the same class, I decided to split the functions into multiple classes. Given that the only kind of interpolation we need right now is intraday I created only this kind.

#### test(interpolation_filter):
Finally some tests for interpolation filter!

## Picture of a cute animal
![Cute](https://media.giphy.com/media/ETTzs1c6mS36g/giphy.gif)