### PR TITLE
Refactor README.md and pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,33 +1,21 @@
 ## Premise
-_Address here what was the problem, the trello board, or the issue you are taking care of._
+_Address here what was the problem, the Trello board, or the issue you are taking care of._
 
 ## Features
-_List of changes, use semantic versioning's (or conventional commit's) rules. Be specific about important things that need to be understood, ignore self-explaining changes._
-_List files with keyword as lvl 4 titles and then list internal file changes
-Possible keywords for files:_
-
-**feat(filename)** when adding new features
-**fix(filename)** when fixing something not properly working
-**syle(filename)** when organizing and styling the script
-**doc(filename)** when adding documentation
-**refactor(filename)** when refactoring
-**test(filename)** when adding unit tests
-
-_When listing:_
-
-**+** Use plus for additions
-**-** Use minus for deletions/code removals
-**~** Use tilde for changes
-
-_Remember to surround them with double * otherwise they'll be changed to list bullets_
+_List of change be specific about important things that need to be understood by the reviewer, ignore self-explaining changes._
+_List files with a keyword as level 4 titles and then list internal file changes_
 
 _Example:_
 
-#### feat(`downloader.py`)
+#### `downloader.py`
 **+** Added `choose_folder()` method that lets you decide where to save data
 **~** Changed how files are ordered when listed
 **-** Removed `do_nothing()` mehtod
 
-## Picture of a cute animal
-You MUST place a pic or a gif of a cute animal at the end of the PR.
-![Cute](https://media2.giphy.com/media/5i7umUqAOYYEw/giphy.gif?cid=ecf05e478fddbba1ddf9f9cceb68f655c8eee989efe381a3&rid=giphy.gif)
+## Extras
+
+_If there is something extra you'd like your reviewer to know you can write it here_
+
+## Motivational image
+You MUST place a motivational pic or gif at the end of the pull request.
+![Image](https://media2.giphy.com/media/5i7umUqAOYYEw/giphy.gif?cid=ecf05e478fddbba1ddf9f9cceb68f655c8eee989efe381a3&rid=giphy.gif)

--- a/README.md
+++ b/README.md
@@ -1,19 +1,49 @@
 # Open Trading Research Infrastructure
-Open Trading Research Infrastructure.
 
-## config.json
+**Open Trading Research Infrastructure (OTRI)** is a research platform for financial computing focusing on data retrieval, validation and analysis.
+
+## Usage
+
+### Requirements
+
+- Any OS that supports Python 3.7
+- Python 3.7 and PIP
+
+### Installation
+
+```bash
+$~: git clone https://github.com/OTRI-Unipd/OTRI
+$~: cd OTRI
+$~: pip install -r requirements.txt
+```
+
+### Configuration files
+
 In order to work properly most scripts require a `config.json` with the following structure:
 
 ```JSON
 {
     "postgre_username" : "",
     "postgre_password" : "",
+    "postgre_database" : "",
     "postgre_host" : "",
     "alphavantage_api_key": ""
 }
 ```
 
+Or alternatively a `/secrets` directory containing extension-less files having file name as key and file contents as value. This is useful when passing configuration values to the Docker image as a volume.
+
+```bash
+secrets
+├─── postgre_username
+├─── postgre_password
+├─── postgre_database
+├─── postgre_host
+└─── alphavantage_api_key
+```
+
 ## Copyrigth
+
 ```
   Copyright 2020 OTRI. All rights reserved.
 ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Open Trading Research Infrastructure
 
-**Open Trading Research Infrastructure (OTRI)** is a research platform for financial computing focusing on data retrieval, validation and analysis.
+**Open Trading Research Infrastructure (OTRI)** is a research platform for financial computing focusing on data retrieval, validation, and analysis.
 
-## Usage
+## Getting started
 
 ### Requirements
 
@@ -16,6 +16,18 @@ $~: git clone https://github.com/OTRI-Unipd/OTRI
 $~: cd OTRI
 $~: pip install -r requirements.txt
 ```
+
+### Database
+
+Currently, only a PostgreSQL database is supported.
+The structure of the database is the following:
+
+- An `atoms` table that contains all retrieved data [ID : BigSerial, data_json : jsonb]
+- A `metadata` table that contains static metadata [ID : BigSerial, data_json : jsonb]
+
+To bootstrap scripts, you'll have to populate the `metadata` table with rows that contain the `ticker` key.
+> [!NOTE]
+> There shouldn't be two atoms with the same `ticker` value, consider using a `UNIQUE index`
 
 ### Configuration files
 
@@ -31,7 +43,7 @@ In order to work properly most scripts require a `config.json` with the followin
 }
 ```
 
-Or alternatively a `/secrets` directory containing extension-less files having file name as key and file contents as value. This is useful when passing configuration values to the Docker image as a volume.
+Alternatively, a `/secrets` directory containing extension-less files having file name as key and file contents as value. This is useful when passing configuration values to the Docker image as a volume.
 
 ```bash
 secrets


### PR DESCRIPTION
## Premise
Too little information on the main README and too many useless details in the pull request template.
Also wanted the README to look cool because it's in our public profile and will probably end up in our curriculum.

## Features

#### `README.md`

**+** Getting started section containing:
 - Requirements
 - Installation
 - Database

**~** Added the secrets-volume method to the configurations

#### `pull_request_template.md`

Conventional commits are no use for a pull request. Also, there was too much to delete before you can start writing anything.

## Extra

Sadly `pull_request_template.md` changes will take effect only when we merge develop branch in the master branch.

Feel free to add anything if you wanted to.

## MayMay of the week
![image](https://user-images.githubusercontent.com/24541776/89742174-e67ba080-da97-11ea-91a5-c95af4dee984.png)
