### PR TITLE
Temporary stream refactor

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -149,6 +149,5 @@ optional-requirements.txt
 test/
 doc/
 generate_docs.py
-run_all_tests.py
 profile_batch.py
 test.py

--- a/otri/analysis/convergence.py
+++ b/otri/analysis/convergence.py
@@ -10,7 +10,7 @@ from ..filtering.filters.generic_filter import (GenericFilter,
                                                 MultipleGenericFiler)
 from ..filtering.filters.group_filter import TimeseriesGroupFilter
 from ..filtering.filters.threshold_filter import ThresholdFilter
-from ..filtering.stream import LocalStream
+from ..filtering.stream import LocalStream, Stream
 from ..utils import key_handler as kh
 from ..utils import time_handler as th
 from . import Analysis

--- a/otri/analysis/convergence.py
+++ b/otri/analysis/convergence.py
@@ -1,6 +1,7 @@
 
 import functools
 from datetime import datetime, timedelta, timezone
+from typing import Sequence
 
 from ..filtering.filter import Any, Filter, Mapping
 from ..filtering.filter_net import EXEC_AND_PASS, FilterLayer, FilterNet
@@ -9,9 +10,10 @@ from ..filtering.filters.generic_filter import (GenericFilter,
                                                 MultipleGenericFiler)
 from ..filtering.filters.group_filter import TimeseriesGroupFilter
 from ..filtering.filters.threshold_filter import ThresholdFilter
+from ..filtering.stream import LocalStream
 from ..utils import key_handler as kh
 from ..utils import time_handler as th
-from . import Analysis, Sequence, Stream
+from . import Analysis
 
 
 class RatioFilter(Filter):
@@ -123,7 +125,7 @@ class ConvergenceAnalysis(Analysis):
                 Two time series streams to analyise, must contain same-interval atoms with 'close' key.
         '''
         # Prepare output_streams
-        output_streams = [Stream(), Stream()]
+        output_streams = [LocalStream(), LocalStream()]
         # Calculate ratios ever ratio_interval
         convergence_net = FilterNet(layers=[
             FilterLayer([

--- a/otri/database/database_stream.py
+++ b/otri/database/database_stream.py
@@ -11,6 +11,12 @@ class DatabaseStream(Stream):
         '''
         pass
 
+    def __eq__(self, other):
+        '''
+        Avoids
+        '''
+        pass
+
     def push(self, element : Any):
         raise RuntimeError("cannot push data into a DatabaseStream")
 

--- a/otri/database/database_stream.py
+++ b/otri/database/database_stream.py
@@ -1,33 +1,15 @@
-from typing import Tuple, Any, Iterable
-from ..filtering.stream import Stream
+from typing import Any
+from ..filtering.stream import ReadableStream
 
-class DatabaseStream(Stream):
+
+class DatabaseStream(ReadableStream):
     '''
-    A stream that can't have data pushed in, only read from the database.
+    A stream that contains data from the database.
+
+    TODO: find a meaning for this class.
     '''
-    def __init__(self):
-        '''
-        Avoids calling Stream class init if subclass doesn't override it.
-        '''
-        pass
+    pass
 
-    def __eq__(self, other):
-        '''
-        Avoids
-        '''
-        pass
-
-    def push(self, element : Any):
-        raise RuntimeError("cannot push data into a DatabaseStream")
-
-    def push_all(self, elements : Iterable):
-        raise RuntimeError("cannot push data into a DatabaseStream")
-
-    def has_next(self):
-        raise NotImplementedError("DatabaseStream is an abstract class, implement has_next in a sublcass")
-
-    def clear(self):
-        raise RuntimeError("cannot clear a DatabaseStream")
 
 class PostgreSQLStream(DatabaseStream):
 
@@ -53,7 +35,7 @@ class PostgreSQLStream(DatabaseStream):
         self.__cursor.execute(query)
         self.__buffer = None
 
-    def pop(self)-> Any:
+    def pop(self) -> Any:
         '''
         Returns:
             The first element of the given query result.\n
@@ -62,7 +44,7 @@ class PostgreSQLStream(DatabaseStream):
         '''
         if self.__cursor.closed:
             raise IndexError("DatabaseStream empty")
-        if self.__buffer != None:
+        if self.__buffer is not None:
             item = self.__buffer
             self.__buffer = None
             return item
@@ -73,12 +55,12 @@ class PostgreSQLStream(DatabaseStream):
                 self.close()
                 raise
 
-    def has_next(self)->bool:
+    def has_next(self) -> bool:
         '''
         Returns:
             True if the stream contains data, false otherwise.\n
         '''
-        if self.__buffer != None:
+        if self.__buffer is not None:
             return True
         try:
             self.__buffer = next(self.__cursor)
@@ -94,7 +76,7 @@ class PostgreSQLStream(DatabaseStream):
         super().close()
         self.__connection.close()
 
-    def __new_cursor(self, connection, batch_size : int):
+    def __new_cursor(self, connection, batch_size: int):
         '''
         Parameters:\n
             connection

--- a/otri/database/database_stream.py
+++ b/otri/database/database_stream.py
@@ -1,4 +1,4 @@
-from typing import Any, Tuple, Mapping
+from typing import Any, Tuple, Mapping, Union
 from ..filtering.stream import ReadableStream
 
 __version__ = "2.0"

--- a/otri/database/postgresql_adapter.py
+++ b/otri/database/postgresql_adapter.py
@@ -42,7 +42,7 @@ class PostgreSQLAdapter(DatabaseAdapter):
         '''
         super().__init__(password, host, port, user, database)
 
-    def stream(self, query: Query, batch_size: int = 1000) -> PostgreSQLStream:
+    def stream(self, query: Query, batch_size: int = 1000, extract_atom: bool = False) -> PostgreSQLStream:
         '''
         Returns a database stream that performs the given query fetching `batch_size` rows at a
         time. If you need to fetch few rows at a time but do not need a `Stream` object use
@@ -57,6 +57,8 @@ class PostgreSQLAdapter(DatabaseAdapter):
             batch_size : int
                 The number of rows the database should load before making them available.
                 The iterable still always yields a single item.\n
+            extract_atom : bool
+                Whether to return atoms or the whole database tuple.\n
         Returns:
             An Iterable stream of database rows that match the query.
         '''
@@ -64,7 +66,7 @@ class PostgreSQLAdapter(DatabaseAdapter):
             raise ValueError("Not an SQLAlchemy query.")
 
         query = query.statement.compile(self._engine, compile_kwargs={"literal_binds": True}).string
-        return PostgreSQLStream(self._engine.raw_connection(), query, batch_size)
+        return PostgreSQLStream(self._engine.raw_connection(), query=query, batch_size=batch_size, extract_atom=extract_atom)
 
     def _connection_string(self) -> str:
         '''

--- a/otri/filtering/filter_net.py
+++ b/otri/filtering/filter_net.py
@@ -138,6 +138,12 @@ def EXEC_UNTIL_FINISHED(layer: FilterLayer):
                 return 0
     return 1
 
+def EXEC_UNTIL_EMPTY(layer: FilterLayer):
+    for f in layer.filters:
+        for input_stream in f._get_inputs():
+            if input_stream.has_next():
+                return 0
+    return 1
 
 def EXEC_UNTIL_OUTPUT(layer: FilterLayer):
     if layer.has_outputted():

--- a/otri/filtering/filter_net.py
+++ b/otri/filtering/filter_net.py
@@ -1,6 +1,6 @@
 from typing import Callable, Sequence, Mapping, Any
 from .filter_layer import FilterLayer
-from .stream import Stream
+from .stream import Stream, LocalStream
 
 
 class FilterNet:
@@ -107,13 +107,12 @@ class FilterNet:
     def __get_streams_by_names(self, names: Sequence[str]) -> Sequence[Stream]:
         '''
         Retrieves the required streams as a sequence.
-        If a stream is not found it's initialised and stored into the dict, unless its name is None.
+        If a stream is not found it's initialised as LocalStream and stored into the streams dict.
         '''
         streams = []
         for name in names:
             # setdefault(key, default) returns value if key is present, default otherwise and stores key : default in the dict
-            if name is not None:
-                streams.append(self.stream_dict.setdefault(name, Stream(elements=None, closed=False)))
+            streams.append(self.stream_dict.setdefault(name, LocalStream(elements=None, closed=False)))
         return streams
 
 

--- a/otri/filtering/filter_net.py
+++ b/otri/filtering/filter_net.py
@@ -52,8 +52,7 @@ class FilterNet:
         # Setup phase
         for filter_layer in self.__layers:
             for f in filter_layer.filters:
-                f.setup(self.__get_streams_by_names(f.get_input_names()),
-                        self.__get_streams_by_names(f.get_output_names()), self.state_dict)
+                f.setup(self.__get_streams_by_names(f.input_names),self.__get_streams_by_names(f.output_names), self.state_dict)
 
         # Execute phase
         layer_index = 0
@@ -99,7 +98,7 @@ class FilterNet:
         '''
 
         for l_filter in self.__layers[len(self.__layers) - 1].filters:
-            for output_stream_name in l_filter.get_output_names():
+            for output_stream_name in l_filter.output_names:
                 # If even one of the output streams is not closed, then continue execution
                 if output_stream_name is not None and not self.stream_dict[output_stream_name].is_closed():
                     return False
@@ -114,7 +113,7 @@ class FilterNet:
         for name in names:
             # setdefault(key, default) returns value if key is present, default otherwise and stores key : default in the dict
             if name is not None:
-                streams.append(self.stream_dict.setdefault(name, Stream(iterable=None, is_closed=False)))
+                streams.append(self.stream_dict.setdefault(name, Stream(elements=None, closed=False)))
         return streams
 
 

--- a/otri/filtering/filters/merge_filter.py
+++ b/otri/filtering/filters/merge_filter.py
@@ -36,4 +36,4 @@ class SequentialMergeFilter(Filter):
         Defines the order for the inputs to be checked.
         We choose it to be sequential.
         '''
-        return range(0, len(self.get_input_names()))
+        return range(0, len(self.input_names))

--- a/otri/filtering/filters/nuplicator_filter.py
+++ b/otri/filtering/filters/nuplicator_filter.py
@@ -34,5 +34,5 @@ class NUplicatorFilter(Filter):
         '''
         Copies reference or deep copies atoms in multiple outputs.
         '''
-        for i in range(len(self.get_output_names())):
+        for i in range(len(self.output_names)):
             self._push_data(self.__copy(data), index = i)

--- a/otri/filtering/filters/split_filter.py
+++ b/otri/filtering/filters/split_filter.py
@@ -87,7 +87,7 @@ class SplitFilter(Filter):
             # Ignoring the item that does not have the key.
             if not self.__ignore_none:
                 # Append void atom on last output
-                self._push_data(data, len(self.get_output_names()) - 1)
+                self._push_data(data, len(self.output_names) - 1)
 
 
 class SwitchFilter(Filter):

--- a/otri/filtering/stream.py
+++ b/otri/filtering/stream.py
@@ -2,7 +2,7 @@
 from collections import deque
 from typing import Iterable, Any
 
-def ClosedStreamError(ValueError):
+class ClosedStreamError(ValueError):
     pass
 
 class Stream:
@@ -22,7 +22,7 @@ class Stream:
             self.__deque = deque(elements)
         else:
             self.__deque = deque()
-        self.__closed = closed
+        self._closed = closed
 
     def push(self, element : Any):
         '''
@@ -82,11 +82,18 @@ class Stream:
     read = pop
     dequeue = pop
 
+    def clear(self):
+        '''
+        Removes all elements from the Stream.
+        '''
+        self.__deque.clear()
+
     def is_closed(self) -> bool:
         '''
-        Defines if new data can be added to the stream.
+        Returns:
+            True if new data cannot be added to the stream, False otherwise.
         '''
-        return self.__closed
+        return self._closed
 
     def close(self):
         '''
@@ -95,9 +102,9 @@ class Stream:
         Raises:\n
             ClosedStreamError - if the stream has already been closed.\n
         '''
-        if not self.is_closed():
+        if self.is_closed():
             raise ClosedStreamError("stream is already closed, can not flag it closed again")
-        self.__is_closed = True
+        self._closed = True
         
 def VoidStream(Stream):
     '''

--- a/otri/filtering/stream.py
+++ b/otri/filtering/stream.py
@@ -20,7 +20,7 @@ class Stream:
         closed : bool
                 Define if new data can be written in the stream.\n
         '''
-        if(elements != None):
+        if(elements is not None):
             self._deque = deque(elements)
         else:
             self._deque = deque()

--- a/otri/filtering/stream.py
+++ b/otri/filtering/stream.py
@@ -1,6 +1,11 @@
 
 from collections import deque
 from typing import Iterable, Any
+from abc import ABC, abstractmethod
+
+
+__version__ = "2.0"
+__author__ = "Riccardo De Zen <riccardodezen98@gmail.com>, Luca Crema <lc.crema@hotmail.com>"
 
 
 class ClosedStreamError(ValueError):
@@ -9,7 +14,137 @@ class ClosedStreamError(ValueError):
 
 class Stream:
     '''
-    FIFO queue-like collection that can be open to new data or closed.
+    Interface for a collection of data that can only be popped/dequeued and not topped/peeked.
+
+    Data can be read from it if it's a ReadableStream or pushed into it if it's a WritableStream.
+
+    The stream is defined as open if more data can be added or read (but maybe it's not in the stream at the moment).
+    When it's closed the data can be read until the stream is empty but nothing can be added to it.
+    '''
+
+    def __init__(self):
+        self._closed = False
+
+    def is_closed(self) -> bool:
+        '''
+        Returns:
+            False if new data could be added to the stream, True otherwise.
+        '''
+        return self._closed
+
+    def close(self):
+        '''
+        Prevents the stream from getting new data, data contained can still be read.\n
+
+        Raises:\n
+            ClosedStreamError - if the stream has already been closed.\n
+        '''
+        if self.is_closed():
+            raise ClosedStreamError("{} is already closed, can not flag it closed again".format(self.__class__))
+        self._closed = True
+
+
+class ReadableStream(ABC, Stream):
+    '''
+    Stream where data can be read.
+    '''
+
+    @abstractmethod
+    def has_next(self) -> bool:
+        '''
+        Checks if the stream contains data ready to be read. Independent from the stream closeness.
+
+        Returns:
+            True if the stream contains data, False otherwise.\n
+        '''
+        raise NotImplementedError()
+
+    @abstractmethod
+    def pop(self) -> Any:
+        '''
+        Returns:
+            The first element of the stream.\n
+        Raises:
+            IndexError - if there is no data available, independently from the stream closeness.
+        '''
+        raise NotImplementedError()
+
+    # Pop aliases
+    read = pop
+    dequeue = pop
+
+
+class WritableStream(ABC, Stream):
+    '''
+    Stream where data can be pushed.
+
+    Uses Template design pattern to have close-ness checks in common.
+    '''
+
+    def push(self, element: Any):
+        '''
+        Pushes an element into the stream.\n
+
+        Parameters:\n
+            element : Any
+                A single element to push into the stream.\n
+        Raises:\n
+            ClosedStreamError - if the stream is flagged as closed.\n
+        '''
+        if self.is_closed():
+            raise ClosedStreamError("{} is flagged as closed but it is still being modified".format(self.__class__))
+        self._push(element=element)
+
+    @abstractmethod
+    def _push(self, element: Any):
+        '''
+        Called after common checks.
+
+        Parameters:\n
+            element : Any
+                A single element to push into the stream.\n
+        '''
+        pass
+
+    # Push aliases
+    write = push
+    enqueue = push
+    append = push
+
+    def push_all(self, elements: Iterable):
+        '''
+        Pushes multiple elements inside the stream.\n
+
+        Parameters:\n
+            elements : Iterable
+                A collection of elements to push into the stream.\n
+        Raises:\n
+            ClosedStreamError - if the stream is flagged as closed.\n
+        '''
+        if self.is_closed():
+            raise ClosedStreamError("{} is flagged as closed but it is still being modified".format(self.__class__))
+        self._push_all(elements=elements)
+
+    @abstractmethod
+    def _push_all(self, elements: Iterable):
+        '''
+        Called after common checks.
+
+        Parameters:\n
+            elements : Iterable
+                A collection of elements to push into the stream.\n
+        '''
+        pass
+
+    # Push_all aliases
+    write_all = push_all
+    enqueue_all = push_all
+    extend = push_all
+
+
+class LocalStream(ReadableStream, WritableStream):
+    '''
+    FIFO queue-like stream.
     '''
 
     def __init__(self, elements: Iterable = None, closed: bool = False):
@@ -34,128 +169,45 @@ class Stream:
             return NotImplemented
         return self._deque == other._deque  # and (self.is_closed == other.is_closed)
 
-    def push(self, element: Any):
-        '''
-        Pushes an element into the stream.\n
-
-        Parameters:\n
-            element : Any
-                A single element to push into the stream.\n
-        Raises:\n
-            ClosedStreamError - if the stream is flagged as closed.\n
-        '''
-        if self.is_closed():
-            raise ClosedStreamError("stream is flagged as closed but it is still being modified")
+    def _push(self, element: Any):
         return self._deque.append(element)
 
-    # Push aliases
-    write = push
-    enqueue = push
-    append = push
-
-    def push_all(self, elements: Iterable):
-        '''
-        Pushes multiple elements inside the stream.\n
-
-        Parameters:\n
-            elements : Iterable
-                A collection of elements to push into the stream.\n
-        Raises:\n
-            ClosedStreamError - if the stream is flagged as closed.\n
-        '''
-        if self.is_closed():
-            raise ClosedStreamError("stream is flagged as closed but it is still being modified")
+    def _push_all(self, elements: Iterable):
         return self._deque.extend(elements)
 
-    # Push_all aliases
-    write_all = push_all
-    enqueue_all = push_all
-    extend = push_all
-
     def has_next(self) -> bool:
-        '''
-        Returns:
-            True if the stream contains data, false otherwise.\n
-        '''
         return len(self._deque) > 0
 
     def pop(self) -> Any:
-        '''
-        Returns:
-            The first element in the First-in First-out order.\n
-        Raises:
-            IndexError - if there is no data available.
-        '''
         return self._deque.popleft()
 
     # Pop aliases
     read = pop
     dequeue = pop
 
-    def clear(self):
+    def clear(self) -> list:
         '''
-        Removes all elements from the Stream.
+        Removes all elements from the Stream and returns a list containing data.
         '''
+        ret_list = list(self._deque)
         self._deque.clear()
-
-    def is_closed(self) -> bool:
-        '''
-        Returns:
-            True if new data cannot be added to the stream, False otherwise.
-        '''
-        return self._closed
-
-    def close(self):
-        '''
-        Prevents the stream from getting new data, data contained can still be iterated.\n
-
-        Raises:\n
-            ClosedStreamError - if the stream has already been closed.\n
-        '''
-        if self.is_closed():
-            raise ClosedStreamError("stream is already closed, can not flag it closed again")
-        self._closed = True
+        return ret_list
 
 
-def VoidStream(Stream):
+class VoidStream(WritableStream):
     '''
     A Stream that discards everything it's added to it.
     Used in filter nets to discard unused data.
     '''
 
-    def push(self, element: Any):
+    def _push(self, element: Any):
         '''
-        Discards passed data.\n
-
-        Parameters:\n
-            element : Any
-                A single element to discard.\n
-        Raises:\n
-            ClosedStreamError - if the stream is flagged as closed.\n
+        Discards passed data.
         '''
-        if self.is_closed():
-            raise ClosedStreamError("stream is flagged as closed but it is still being modified")
         del element
 
-    def push_all(self, elements: Iterable):
+    def _push_all(self, elements: Iterable):
         '''
-        Discards passed data.\n
-
-        Parameters:\n
-            elements : Iterable
-                A collection of elements to discard.\n
-        Raises:\n
-            ClosedStreamError - if the stream is flagged as closed.\n
+        Discards passed data.
         '''
-        if self.is_closed():
-            raise ClosedStreamError("stream is flagged as closed but it is still being modified")
         del elements
-
-    def pop(self) -> Any:
-        '''
-        Returns:
-            The first element in the First-in First-out order.\n
-        Raises:
-            IndexError - if there is no data available.
-        '''
-        raise IndexError("cannot read data from Void Stream")

--- a/otri/filtering/stream.py
+++ b/otri/filtering/stream.py
@@ -2,8 +2,10 @@
 from collections import deque
 from typing import Iterable, Any
 
+
 class ClosedStreamError(ValueError):
     pass
+
 
 class Stream:
     '''
@@ -19,12 +21,20 @@ class Stream:
                 Define if new data can be written in the stream.\n
         '''
         if(elements != None):
-            self.__deque = deque(elements)
+            self._deque = deque(elements)
         else:
-            self.__deque = deque()
+            self._deque = deque()
         self._closed = closed
 
-    def push(self, element : Any):
+    def __eq__(self, other):
+        '''
+        Checks for equality. Does not touch the two streams' data.
+        '''
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self._deque == other._deque  # and (self.is_closed == other.is_closed)
+
+    def push(self, element: Any):
         '''
         Pushes an element into the stream.\n
 
@@ -36,14 +46,14 @@ class Stream:
         '''
         if self.is_closed():
             raise ClosedStreamError("stream is flagged as closed but it is still being modified")
-        return self.__deque.append(element)
+        return self._deque.append(element)
 
     # Push aliases
     write = push
     enqueue = push
     append = push
 
-    def push_all(self, elements : Iterable):
+    def push_all(self, elements: Iterable):
         '''
         Pushes multiple elements inside the stream.\n
 
@@ -55,19 +65,19 @@ class Stream:
         '''
         if self.is_closed():
             raise ClosedStreamError("stream is flagged as closed but it is still being modified")
-        return self.__deque.extend(elements)
+        return self._deque.extend(elements)
 
     # Push_all aliases
     write_all = push_all
     enqueue_all = push_all
     extend = push_all
 
-    def has_next(self)->bool:
+    def has_next(self) -> bool:
         '''
         Returns:
             True if the stream contains data, false otherwise.\n
         '''
-        return len(self.__deque) > 0
+        return len(self._deque) > 0
 
     def pop(self) -> Any:
         '''
@@ -76,7 +86,7 @@ class Stream:
         Raises:
             IndexError - if there is no data available.
         '''
-        return self.__deque.popleft()
+        return self._deque.popleft()
 
     # Pop aliases
     read = pop
@@ -86,7 +96,7 @@ class Stream:
         '''
         Removes all elements from the Stream.
         '''
-        self.__deque.clear()
+        self._deque.clear()
 
     def is_closed(self) -> bool:
         '''
@@ -105,14 +115,15 @@ class Stream:
         if self.is_closed():
             raise ClosedStreamError("stream is already closed, can not flag it closed again")
         self._closed = True
-        
+
+
 def VoidStream(Stream):
     '''
     A Stream that discards everything it's added to it.
     Used in filter nets to discard unused data.
     '''
 
-    def push(self, element : Any):
+    def push(self, element: Any):
         '''
         Discards passed data.\n
 
@@ -126,7 +137,7 @@ def VoidStream(Stream):
             raise ClosedStreamError("stream is flagged as closed but it is still being modified")
         del element
 
-    def push_all(self, elements : Iterable):
+    def push_all(self, elements: Iterable):
         '''
         Discards passed data.\n
 

--- a/otri/filtering/stream.py
+++ b/otri/filtering/stream.py
@@ -190,6 +190,11 @@ class LocalStream(ReadableStream, WritableStream):
     def _pop(self) -> Any:
         return self._deque.popleft()
 
+    def __len__(self):
+        return len(self._deque)
+
+    count = __len__
+
     def clear(self) -> list:
         '''
         Removes all elements from the Stream and returns a list containing data.

--- a/otri/filtering/stream.py
+++ b/otri/filtering/stream.py
@@ -52,22 +52,31 @@ class ReadableStream(ABC, Stream):
     @abstractmethod
     def has_next(self) -> bool:
         '''
-        Checks if the stream contains data ready to be read. Independent from the stream closeness.
+        Checks if the stream contains data ready to be read. Independent from the stream close state.
 
         Returns:
             True if the stream contains data, False otherwise.\n
         '''
         raise NotImplementedError()
 
-    @abstractmethod
     def pop(self) -> Any:
         '''
+        Removes an element from the stream and returns it.\n
+        It's recommended making sure there's some data to read with has_next().\n
+
         Returns:
             The first element of the stream.\n
         Raises:
-            IndexError - if there is no data available, independently from the stream closeness.
+            IndexError - if there is no data available, independently from the stream close state.
         '''
-        raise NotImplementedError()
+        return self._pop()
+
+    @abstractmethod
+    def _pop(self) -> Any:
+        '''
+        Called after common checks. Removes one element of the stream.\n
+        '''
+        pass
 
     # Pop aliases
     read = pop
@@ -178,12 +187,8 @@ class LocalStream(ReadableStream, WritableStream):
     def has_next(self) -> bool:
         return len(self._deque) > 0
 
-    def pop(self) -> Any:
+    def _pop(self) -> Any:
         return self._deque.popleft()
-
-    # Pop aliases
-    read = pop
-    dequeue = pop
 
     def clear(self) -> list:
         '''
@@ -192,6 +197,8 @@ class LocalStream(ReadableStream, WritableStream):
         ret_list = list(self._deque)
         self._deque.clear()
         return ret_list
+
+    to_list = clear
 
 
 class VoidStream(WritableStream):

--- a/run_all_tests.bat
+++ b/run_all_tests.bat
@@ -1,0 +1,1 @@
+cmd /c "python -m pytest -s"

--- a/run_all_tests.py
+++ b/run_all_tests.py
@@ -1,3 +1,0 @@
-import os
-
-os.system('cmd /c "python -m pytest -s"')

--- a/test/filtering/filter_net_test.py
+++ b/test/filtering/filter_net_test.py
@@ -16,7 +16,7 @@ class FilterNetTest(unittest.TestCase):
                 )
             ], EXEC_AND_PASS)
         ])
-        self.input = Stream(EX_DATA, is_closed=True)
+        self.input = Stream(EX_DATA, closed=True)
 
     def test_add_layer_works(self):
         self.fl.add_layer(FilterLayer([

--- a/test/filtering/filter_net_test.py
+++ b/test/filtering/filter_net_test.py
@@ -29,4 +29,4 @@ class FilterNetTest(unittest.TestCase):
 
     def test_normal_execution(self):
         self.fl.execute({"A":self.input})
-        self.assertEqual(self.fl.streams()['B'],[2,3,4,5,6])
+        self.assertEqual(self.fl.streams()['B'],Stream([2,3,4,5,6]))

--- a/test/filtering/filter_net_test.py
+++ b/test/filtering/filter_net_test.py
@@ -1,8 +1,10 @@
-from otri.filtering.filter_net import Stream, FilterNet, FilterLayer, EXEC_AND_PASS
+from otri.filtering.filter_net import FilterNet, FilterLayer, EXEC_AND_PASS
 from otri.filtering.filters.generic_filter import GenericFilter
+from otri.filtering.stream import LocalStream
 import unittest
 
-EX_DATA = [1,2,3,4,5]
+EX_DATA = [1, 2, 3, 4, 5]
+
 
 class FilterNetTest(unittest.TestCase):
 
@@ -16,7 +18,7 @@ class FilterNetTest(unittest.TestCase):
                 )
             ], EXEC_AND_PASS)
         ])
-        self.input = Stream(EX_DATA, closed=True)
+        self.input = LocalStream(EX_DATA, closed=True)
 
     def test_add_layer_works(self):
         self.fl.add_layer(FilterLayer([
@@ -28,5 +30,5 @@ class FilterNetTest(unittest.TestCase):
         ], EXEC_AND_PASS))
 
     def test_normal_execution(self):
-        self.fl.execute({"A":self.input})
-        self.assertEqual(self.fl.streams()['B'],Stream([2,3,4,5,6]))
+        self.fl.execute({"A": self.input})
+        self.assertEqual(self.fl.streams()['B'], LocalStream([2, 3, 4, 5, 6]))

--- a/test/filtering/filter_test.py
+++ b/test/filtering/filter_test.py
@@ -1,4 +1,5 @@
-from otri.filtering.filter import Filter, Stream
+from otri.filtering.filter import Filter
+from otri.filtering.stream import LocalStream
 from unittest.mock import MagicMock
 import unittest
 
@@ -6,11 +7,11 @@ import unittest
 class FilterTest(unittest.TestCase):
 
     def setUp(self):
-        self.s_A = Stream([1, 2, 3])
-        self.s_B = Stream([3, 4, 5])
-        self.s_D = Stream()
-        self.s_E = Stream()
-        self.s_F = Stream()
+        self.s_A = LocalStream([1, 2, 3])
+        self.s_B = LocalStream([3, 4, 5])
+        self.s_D = LocalStream()
+        self.s_E = LocalStream()
+        self.s_F = LocalStream()
         self.state = dict()
         self.f = Filter(
             inputs=["A", "B"],
@@ -55,14 +56,14 @@ class FilterTest(unittest.TestCase):
     def test_execute_on_data(self):
         self.f._on_data = MagicMock()
         self.f.execute()
-        self.assertTrue( self.f._on_data.called)
+        self.assertTrue(self.f._on_data.called)
 
     def test_execute_input_empty(self):
         self.s_A.clear()
         self.s_B.clear()
         self.f._on_inputs_empty = MagicMock()
         self.f.execute()
-        self.assertTrue( self.f._on_inputs_empty.called)
+        self.assertTrue(self.f._on_inputs_empty.called)
 
     def test_execute_input_closed(self):
         self.s_A.clear()
@@ -71,7 +72,7 @@ class FilterTest(unittest.TestCase):
         self.s_B.close()
         self.f._on_inputs_closed = MagicMock()
         self.f.execute()
-        self.assertTrue( self.f._on_inputs_closed.called)
+        self.assertTrue(self.f._on_inputs_closed.called)
 
     def test_default_on_inputs_closed_closes_outputs(self):
         self.s_A.clear()
@@ -79,6 +80,6 @@ class FilterTest(unittest.TestCase):
         self.s_A.close()
         self.s_B.close()
         self.f.execute()
-        self.assertTrue( self.f._get_outputs()[0].is_closed())
-        self.assertTrue( self.f._get_outputs()[1].is_closed())
-        self.assertTrue( self.f._get_outputs()[2].is_closed())
+        self.assertTrue(self.f._get_outputs()[0].is_closed())
+        self.assertTrue(self.f._get_outputs()[1].is_closed())
+        self.assertTrue(self.f._get_outputs()[2].is_closed())

--- a/test/filtering/filter_test.py
+++ b/test/filtering/filter_test.py
@@ -42,7 +42,7 @@ class FilterTest(unittest.TestCase):
 
     def test_push_data(self):
         self.f._push_data(5, 0)
-        self.assertEqual(5, self.s_D.__iter__().__next__())
+        self.assertEqual(5, self.s_D.pop())
 
     def test_execute_outputs_closed(self):
         self.s_D.close()

--- a/test/filtering/filter_test.py
+++ b/test/filtering/filter_test.py
@@ -21,38 +21,24 @@ class FilterTest(unittest.TestCase):
         self.f.setup([self.s_A, self.s_B], [self.s_D, self.s_E, self.s_F], self.state)
 
     def test_filter_input_number_correct(self):
-        self.assertEqual(2, len(self.f.get_input_names()))
+        self.assertEqual(2, len(self.f.input_names))
 
     def test_filter_input_stream_names_equals(self):
-        self.assertEqual(["A", "B"], self.f.get_input_names())
+        self.assertEqual(["A", "B"], self.f.input_names)
 
     def test_filter_output_number_correct(self):
-        self.assertEqual(3, len(self.f.get_output_names()))
+        self.assertEqual(3, len(self.f.output_names))
 
     def test_filter_output_stream_names_equals(self):
-        self.assertEqual(["D", "E", "F"], self.f.get_output_names())
+        self.assertEqual(["D", "E", "F"], self.f.output_names)
 
     def test_get_in_streams(self):
-        self.assertEqual(self.s_A, self.f._get_input(0))
-        self.assertEqual(self.s_B, self.f._get_input(1))
+        self.assertEqual(self.s_A, self.f._get_inputs()[0])
+        self.assertEqual(self.s_B, self.f._get_inputs()[1])
 
     def test_get_out_streams(self):
-        self.assertEqual(self.s_D, self.f._get_output(0))
-        self.assertEqual(self.s_E, self.f._get_output(1))
-        self.assertEqual(self.s_F, self.f._get_output(2))
-
-    def test_get_in_iters(self):
-        self.assertEqual(iter(self.s_A), self.f._get_in_iter(0))
-        self.assertEqual(iter(self.s_B), self.f._get_in_iter(1))
-
-    def test_get_out_iters(self):
-        self.assertEqual(iter(self.s_D), self.f._get_out_iter(0))
-        self.assertEqual(iter(self.s_E), self.f._get_out_iter(1))
-        self.assertEqual(iter(self.s_F), self.f._get_out_iter(2))
-
-    def test_pop_data(self):
-        self.assertEqual(1, self.f._pop_data(0))
-        self.assertEqual(3, self.f._pop_data(1))
+        outputs = self.f._get_outputs()
+        self.assertEqual([self.s_D, self.s_E, self.s_F], outputs)
 
     def test_push_data(self):
         self.f._push_data(5, 0)
@@ -93,6 +79,6 @@ class FilterTest(unittest.TestCase):
         self.s_A.close()
         self.s_B.close()
         self.f.execute()
-        self.assertTrue( self.f._get_output(0).is_closed())
-        self.assertTrue( self.f._get_output(1).is_closed())
-        self.assertTrue( self.f._get_output(2).is_closed())
+        self.assertTrue( self.f._get_outputs()[0].is_closed())
+        self.assertTrue( self.f._get_outputs()[1].is_closed())
+        self.assertTrue( self.f._get_outputs()[2].is_closed())

--- a/test/filtering/filters/align_filter_test.py
+++ b/test/filtering/filters/align_filter_test.py
@@ -40,4 +40,4 @@ class AlignFilterTest(unittest.TestCase):
         self.align_filter.setup([a, b], [c, d], None)
         while not c.is_closed():
             self.align_filter.execute()
-        self.assertEqual(c, EXPECTED[0])
+        self.assertEqual(c, Stream(EXPECTED[0]))

--- a/test/filtering/filters/align_filter_test.py
+++ b/test/filtering/filters/align_filter_test.py
@@ -33,8 +33,8 @@ class AlignFilterTest(unittest.TestCase):
         self.align_filter = AlignFilter(inputs=["A", "B"], outputs=["C", "D"], datetime_key="datetime")
 
     def test_alignment(self):
-        a = Stream(STREAMS[0], is_closed=True)
-        b = Stream(STREAMS[1], is_closed=True)
+        a = Stream(STREAMS[0], closed=True)
+        b = Stream(STREAMS[1], closed=True)
         c = Stream()
         d = Stream()
         self.align_filter.setup([a, b], [c, d], None)

--- a/test/filtering/filters/align_filter_test.py
+++ b/test/filtering/filters/align_filter_test.py
@@ -1,6 +1,6 @@
 import unittest
 from otri.filtering.filters.align_filter import AlignFilter
-from otri.filtering.stream import Stream
+from otri.filtering.stream import LocalStream
 
 STREAMS = [
     [
@@ -33,11 +33,11 @@ class AlignFilterTest(unittest.TestCase):
         self.align_filter = AlignFilter(inputs=["A", "B"], outputs=["C", "D"], datetime_key="datetime")
 
     def test_alignment(self):
-        a = Stream(STREAMS[0], closed=True)
-        b = Stream(STREAMS[1], closed=True)
-        c = Stream()
-        d = Stream()
+        a = LocalStream(STREAMS[0], closed=True)
+        b = LocalStream(STREAMS[1], closed=True)
+        c = LocalStream()
+        d = LocalStream()
         self.align_filter.setup([a, b], [c, d], None)
         while not c.is_closed():
             self.align_filter.execute()
-        self.assertEqual(c, Stream(EXPECTED[0]))
+        self.assertEqual(c, LocalStream(EXPECTED[0]))

--- a/test/filtering/filters/generic_filter_test.py
+++ b/test/filtering/filters/generic_filter_test.py
@@ -16,7 +16,7 @@ class GenericFilterTest(unittest.TestCase):
 
     def test_simple_stream_applies(self):
         # Testing the method is applied to all the elements of the input stream
-        expected = [EXAMPLE_OP(x) for x in range(100)]
+        expected = Stream([EXAMPLE_OP(x) for x in range(100)])
         self.s_A = Stream(list(range(100)), closed=True)
         self.gen_filter.setup([self.s_A], [self.s_B], None)
         while not self.s_B.is_closed():
@@ -37,7 +37,7 @@ class MultipleGenericFilterTest(unittest.TestCase):
         self.gen_filter = MultipleGenericFiler(inputs=["A", "B"], outputs="C", operation=MULTIPLE_EXAMPLE_OP)
 
     def test_simple_stream_applies(self):
-        expected = [3, 5, 7, 9]
+        expected = Stream([3, 5, 7, 9])
         a = Stream([1, 2, 3, 4], closed=True)
         b = Stream([2, 3, 4, 5], closed=True)
         c = Stream()

--- a/test/filtering/filters/generic_filter_test.py
+++ b/test/filtering/filters/generic_filter_test.py
@@ -1,6 +1,6 @@
 import unittest
 from otri.filtering.filters.generic_filter import GenericFilter, MultipleGenericFiler
-from otri.filtering.stream import Stream
+from otri.filtering.stream import LocalStream
 
 
 def EXAMPLE_OP(x): return x + 1
@@ -9,15 +9,15 @@ def EXAMPLE_OP(x): return x + 1
 class GenericFilterTest(unittest.TestCase):
 
     def setUp(self):
-        self.s_A = Stream()
-        self.s_B = Stream()
+        self.s_A = LocalStream()
+        self.s_B = LocalStream()
         self.gen_filter = GenericFilter(
             inputs="A", outputs="B", operation=EXAMPLE_OP)
 
     def test_simple_stream_applies(self):
         # Testing the method is applied to all the elements of the input stream
-        expected = Stream([EXAMPLE_OP(x) for x in range(100)])
-        self.s_A = Stream(list(range(100)), closed=True)
+        expected = LocalStream([EXAMPLE_OP(x) for x in range(100)])
+        self.s_A = LocalStream(list(range(100)), closed=True)
         self.gen_filter.setup([self.s_A], [self.s_B], None)
         while not self.s_B.is_closed():
             self.gen_filter.execute()
@@ -37,10 +37,10 @@ class MultipleGenericFilterTest(unittest.TestCase):
         self.gen_filter = MultipleGenericFiler(inputs=["A", "B"], outputs="C", operation=MULTIPLE_EXAMPLE_OP)
 
     def test_simple_stream_applies(self):
-        expected = Stream([3, 5, 7, 9])
-        a = Stream([1, 2, 3, 4], closed=True)
-        b = Stream([2, 3, 4, 5], closed=True)
-        c = Stream()
+        expected = LocalStream([3, 5, 7, 9])
+        a = LocalStream([1, 2, 3, 4], closed=True)
+        b = LocalStream([2, 3, 4, 5], closed=True)
+        c = LocalStream()
         self.gen_filter.setup([a, b], [c], None)
         while not c.is_closed():
             self.gen_filter.execute()

--- a/test/filtering/filters/generic_filter_test.py
+++ b/test/filtering/filters/generic_filter_test.py
@@ -17,7 +17,7 @@ class GenericFilterTest(unittest.TestCase):
     def test_simple_stream_applies(self):
         # Testing the method is applied to all the elements of the input stream
         expected = [EXAMPLE_OP(x) for x in range(100)]
-        self.s_A = Stream(list(range(100)), is_closed=True)
+        self.s_A = Stream(list(range(100)), closed=True)
         self.gen_filter.setup([self.s_A], [self.s_B], None)
         while not self.s_B.is_closed():
             self.gen_filter.execute()
@@ -38,8 +38,8 @@ class MultipleGenericFilterTest(unittest.TestCase):
 
     def test_simple_stream_applies(self):
         expected = [3, 5, 7, 9]
-        a = Stream([1, 2, 3, 4], is_closed=True)
-        b = Stream([2, 3, 4, 5], is_closed=True)
+        a = Stream([1, 2, 3, 4], closed=True)
+        b = Stream([2, 3, 4, 5], closed=True)
         c = Stream()
         self.gen_filter.setup([a, b], [c], None)
         while not c.is_closed():

--- a/test/filtering/filters/group_filter_test.py
+++ b/test/filtering/filters/group_filter_test.py
@@ -1,6 +1,6 @@
 import unittest
 from otri.filtering.filters.group_filter import TimeseriesGroupFilter
-from otri.filtering.stream import Stream
+from otri.filtering.stream import LocalStream
 from datetime import timedelta
 
 
@@ -69,9 +69,9 @@ class TimeseriesGroupFilterTest(unittest.TestCase):
 
     def __test(self, resolution: timedelta, expected: dict):
         group_filter = TimeseriesGroupFilter(inputs="A", outputs="B", target_resolution=resolution, datetime_key="datetime")
-        a = Stream(STREAM, closed=True)
-        b = Stream()
+        a = LocalStream(STREAM, closed=True)
+        b = LocalStream()
         group_filter.setup([a], [b], None)
         while not b.is_closed():
             group_filter.execute()
-        self.assertEqual(b, Stream(expected))
+        self.assertEqual(b, LocalStream(expected))

--- a/test/filtering/filters/group_filter_test.py
+++ b/test/filtering/filters/group_filter_test.py
@@ -74,4 +74,4 @@ class TimeseriesGroupFilterTest(unittest.TestCase):
         group_filter.setup([a], [b], None)
         while not b.is_closed():
             group_filter.execute()
-        self.assertEqual(b, expected)
+        self.assertEqual(b, Stream(expected))

--- a/test/filtering/filters/group_filter_test.py
+++ b/test/filtering/filters/group_filter_test.py
@@ -69,7 +69,7 @@ class TimeseriesGroupFilterTest(unittest.TestCase):
 
     def __test(self, resolution: timedelta, expected: dict):
         group_filter = TimeseriesGroupFilter(inputs="A", outputs="B", target_resolution=resolution, datetime_key="datetime")
-        a = Stream(STREAM, is_closed=True)
+        a = Stream(STREAM, closed=True)
         b = Stream()
         group_filter.setup([a], [b], None)
         while not b.is_closed():

--- a/test/filtering/filters/interpolation_filter_test.py
+++ b/test/filtering/filters/interpolation_filter_test.py
@@ -34,7 +34,7 @@ ATOMS = [
 class IntradayInterpolationFilterTest(unittest.TestCase):
 
     def setUp(self):
-        self.inputs = [Stream(ATOMS, is_closed=True)]
+        self.inputs = [Stream(ATOMS, closed=True)]
         self.outputs = [Stream()]
         self.f = IntradayInterpolationFilter("in", "out", interp_keys=["close"], target_gap_seconds=60)
         self.f.setup(self.inputs, self.outputs, None)

--- a/test/filtering/filters/interpolation_filter_test.py
+++ b/test/filtering/filters/interpolation_filter_test.py
@@ -42,13 +42,13 @@ class IntradayInterpolationFilterTest(unittest.TestCase):
     def test_single_exec_no_output(self):
         # Assert no output is
         self.f.execute()
-        self.assertEqual(0, len(self.outputs[0]))
+        self.assertFalse(self.f._has_outputted)
 
     def test_starts_from_moring(self):
         # First atom should be at the starting working hour
         self.f.execute()
         self.f.execute()
-        self.assertEqual("2020-04-28 08:00:00.000", self.outputs[0][0]['datetime'])
+        self.assertEqual("2020-04-28 08:00:00.000", self.outputs[0].read()['datetime'])
 
     def test_stops_at_night(self):
         # Last atom is at the end of the day
@@ -59,17 +59,13 @@ class IntradayInterpolationFilterTest(unittest.TestCase):
     def test_avoid_night(self):
         self.f.execute()
         self.f.execute()
-        before_len = len(self.outputs[0])
         # Having another atom later at night should avoid outputting other atoms
         self.f.execute()
-        after_len = len(self.outputs[0])
-        self.assertEqual(before_len, after_len)
+        self.assertFalse(self.f._has_outputted)
 
     def test_avoid_early_morning(self):
         self.f.execute()
         self.f.execute()
         self.f.execute()
-        before_len = len(self.outputs[0])
         self.f.execute()
-        after_len = len(self.outputs[0])
-        self.assertEqual(before_len, after_len)
+        self.assertFalse(self.f._has_outputted)

--- a/test/filtering/filters/interpolation_filter_test.py
+++ b/test/filtering/filters/interpolation_filter_test.py
@@ -1,5 +1,5 @@
 import unittest
-from otri.filtering.stream import Stream
+from otri.filtering.stream import LocalStream
 from otri.filtering.filters.interpolation_filter import IntradayInterpolationFilter
 
 ATOMS = [
@@ -34,8 +34,8 @@ ATOMS = [
 class IntradayInterpolationFilterTest(unittest.TestCase):
 
     def setUp(self):
-        self.inputs = [Stream(ATOMS, closed=True)]
-        self.outputs = [Stream()]
+        self.inputs = [LocalStream(ATOMS, closed=True)]
+        self.outputs = [LocalStream()]
         self.f = IntradayInterpolationFilter("in", "out", interp_keys=["close"], target_gap_seconds=60)
         self.f.setup(self.inputs, self.outputs, None)
 

--- a/test/filtering/filters/interpolation_filter_test.py
+++ b/test/filtering/filters/interpolation_filter_test.py
@@ -54,7 +54,11 @@ class IntradayInterpolationFilterTest(unittest.TestCase):
         # Last atom is at the end of the day
         self.f.execute()
         self.f.execute()
-        self.assertEqual("2020-04-28 20:00:00.000", self.outputs[0][len(self.outputs[0]) - 1]['datetime'])
+        s_list = list()
+        output_stream = self.outputs[0]
+        while output_stream.has_next():
+            s_list.append(output_stream.pop())
+        self.assertEqual("2020-04-28 20:00:00.000", s_list[len(s_list) - 1]['datetime'])
 
     def test_avoid_night(self):
         self.f.execute()

--- a/test/filtering/filters/merge_filter_test.py
+++ b/test/filtering/filters/merge_filter_test.py
@@ -1,30 +1,32 @@
-from otri.filtering.filters.merge_filter import SequentialMergeFilter, Stream
+from otri.filtering.filters.merge_filter import SequentialMergeFilter
+from otri.filtering.stream import LocalStream
 import unittest
+
 
 class SequentialMergeFilterTest(unittest.TestCase):
 
     def setUp(self):
-        self.inputs = [Stream([1,2,3,4],closed=True), Stream([4,5,6,7], closed=True)]
-        self.outputs = [Stream()]
+        self.inputs = [LocalStream([1, 2, 3, 4], closed=True), LocalStream([4, 5, 6, 7], closed=True)]
+        self.outputs = [LocalStream()]
         self.f = SequentialMergeFilter(
-            inputs=["A","B"],
+            inputs=["A", "B"],
             outputs="C"
         )
         self.f.setup(self.inputs, self.outputs, None)
 
     def test_single_execute(self):
         self.f.execute()
-        self.assertEqual([Stream([2,3,4],closed=True),Stream([4,5,6,7], closed=True)], self.inputs)
+        self.assertEqual([LocalStream([2, 3, 4], closed=True), LocalStream([4, 5, 6, 7], closed=True)], self.inputs)
 
     def test_double_execute(self):
         # Ensures that it clears data from the first input first
         self.f.execute()
         self.f.execute()
-        self.assertEqual([Stream([3,4],closed=True),Stream([4,5,6,7], closed=True)], self.inputs)
+        self.assertEqual([LocalStream([3, 4], closed=True), LocalStream([4, 5, 6, 7], closed=True)], self.inputs)
 
     def test_execute_order_async(self):
         # Ensures that it clears data from the first input first
-        in_streams = [Stream([1],closed=False), Stream([2], closed=True)]
+        in_streams = [LocalStream([1], closed=False), LocalStream([2], closed=True)]
         m_filter = SequentialMergeFilter(
             inputs=["A", "B"],
             outputs="C"
@@ -34,13 +36,13 @@ class SequentialMergeFilterTest(unittest.TestCase):
         m_filter.execute()
         in_streams[0].append(3)
         m_filter.execute()
-        self.assertEqual(self.outputs[0], Stream([1,2,3]))
+        self.assertEqual(self.outputs[0], LocalStream([1, 2, 3]))
 
     def test_execute_order_async_2(self):
         # Ensures that it clears data from the first input first
-        in_streams = [Stream([1],closed=False), Stream([2],closed=True)]
+        in_streams = [LocalStream([1], closed=False), LocalStream([2], closed=True)]
         m_filter = SequentialMergeFilter(
-            inputs=["A","B"],
+            inputs=["A", "B"],
             outputs="C"
         )
         m_filter.setup(in_streams, self.outputs, None)
@@ -48,12 +50,12 @@ class SequentialMergeFilterTest(unittest.TestCase):
         in_streams[0].append(3)
         m_filter.execute()
         m_filter.execute()
-        self.assertEqual(Stream(elements=[1,3,2]), self.outputs[0])
+        self.assertEqual(LocalStream(elements=[1, 3, 2]), self.outputs[0])
 
     def test_output_closed(self):
-        in_streams = [Stream([1],closed=False), Stream([2],closed=True)]
+        in_streams = [LocalStream([1], closed=False), LocalStream([2], closed=True)]
         m_filter = SequentialMergeFilter(
-            inputs=["A","B"],
+            inputs=["A", "B"],
             outputs="C"
         )
         m_filter.setup(in_streams, self.outputs, None)
@@ -61,4 +63,4 @@ class SequentialMergeFilterTest(unittest.TestCase):
         m_filter.execute()
         in_streams[0].close()
         m_filter.execute()
-        self.assertEqual(self.outputs[0], Stream([1,2]))
+        self.assertEqual(self.outputs[0], LocalStream([1, 2]))

--- a/test/filtering/filters/merge_filter_test.py
+++ b/test/filtering/filters/merge_filter_test.py
@@ -34,7 +34,7 @@ class SequentialMergeFilterTest(unittest.TestCase):
         m_filter.execute()
         in_streams[0].append(3)
         m_filter.execute()
-        self.assertEqual([1,2,3], self.outputs[0])
+        self.assertEqual(self.outputs[0], Stream([1,2,3]))
 
     def test_execute_order_async_2(self):
         # Ensures that it clears data from the first input first
@@ -61,4 +61,4 @@ class SequentialMergeFilterTest(unittest.TestCase):
         m_filter.execute()
         in_streams[0].close()
         m_filter.execute()
-        self.assertEqual([1,2], self.outputs[0])
+        self.assertEqual(self.outputs[0], Stream([1,2]))

--- a/test/filtering/filters/merge_filter_test.py
+++ b/test/filtering/filters/merge_filter_test.py
@@ -4,7 +4,7 @@ import unittest
 class SequentialMergeFilterTest(unittest.TestCase):
 
     def setUp(self):
-        self.inputs = [Stream([1,2,3,4],is_closed=True), Stream([4,5,6,7], is_closed=True)]
+        self.inputs = [Stream([1,2,3,4],closed=True), Stream([4,5,6,7], closed=True)]
         self.outputs = [Stream()]
         self.f = SequentialMergeFilter(
             inputs=["A","B"],
@@ -14,17 +14,17 @@ class SequentialMergeFilterTest(unittest.TestCase):
 
     def test_single_execute(self):
         self.f.execute()
-        self.assertEqual([Stream([2,3,4],is_closed=True),Stream([4,5,6,7], is_closed=True)], self.inputs)
+        self.assertEqual([Stream([2,3,4],closed=True),Stream([4,5,6,7], closed=True)], self.inputs)
 
     def test_double_execute(self):
         # Ensures that it clears data from the first input first
         self.f.execute()
         self.f.execute()
-        self.assertEqual([Stream([3,4],is_closed=True),Stream([4,5,6,7], is_closed=True)], self.inputs)
+        self.assertEqual([Stream([3,4],closed=True),Stream([4,5,6,7], closed=True)], self.inputs)
 
     def test_execute_order_async(self):
         # Ensures that it clears data from the first input first
-        in_streams = [Stream([1],is_closed=False), Stream([2], is_closed=True)]
+        in_streams = [Stream([1],closed=False), Stream([2], closed=True)]
         m_filter = SequentialMergeFilter(
             inputs=["A", "B"],
             outputs="C"
@@ -38,7 +38,7 @@ class SequentialMergeFilterTest(unittest.TestCase):
 
     def test_execute_order_async_2(self):
         # Ensures that it clears data from the first input first
-        in_streams = [Stream([1],is_closed=False), Stream([2],is_closed=True)]
+        in_streams = [Stream([1],closed=False), Stream([2],closed=True)]
         m_filter = SequentialMergeFilter(
             inputs=["A","B"],
             outputs="C"
@@ -48,10 +48,10 @@ class SequentialMergeFilterTest(unittest.TestCase):
         in_streams[0].append(3)
         m_filter.execute()
         m_filter.execute()
-        self.assertEqual([1,3,2], self.outputs[0])
+        self.assertEqual(Stream(elements=[1,3,2]), self.outputs[0])
 
     def test_output_closed(self):
-        in_streams = [Stream([1],is_closed=False), Stream([2],is_closed=True)]
+        in_streams = [Stream([1],closed=False), Stream([2],closed=True)]
         m_filter = SequentialMergeFilter(
             inputs=["A","B"],
             outputs="C"

--- a/test/filtering/filters/nuplicator_filter_test.py
+++ b/test/filtering/filters/nuplicator_filter_test.py
@@ -24,14 +24,14 @@ class NUplicatorFilterTest(unittest.TestCase):
             self.assertEqual(output.read(), expected)
 
     def test_simple_stream_shallow(self):
-        source_stream = Stream([[["Moshi Moshi"], ["Kawaii Desu"]]])
-        expected = Stream([["Moshi Moshi"], ["Kawaii Desu"]])
-        self.nuplicator.setup([source_stream], self.outputs, None)
+        source_stream = [[["Moshi Moshi"], ["Kawaii Desu"]]]
+        expected = source_stream[0]
+        self.nuplicator.setup([Stream(source_stream)], self.outputs, None)
         self.nuplicator.execute()
         # Changing the inner list, change should be reflected cause copy should be shallow
         expected[0].append("Hello")
         for output in self.outputs:
-            self.assertEqual(output, expected)
+            self.assertEqual(output.read(), expected)
 
     def test_simple_stream_deep(self):
         source_stream = Stream([[["Moshi Moshi"], ["Kawaii Desu"]]])

--- a/test/filtering/filters/nuplicator_filter_test.py
+++ b/test/filtering/filters/nuplicator_filter_test.py
@@ -17,7 +17,7 @@ class NUplicatorFilterTest(unittest.TestCase):
 
     def test_simple_stream_copying(self):
         source_stream = Stream(range(100))
-        expected = source_stream[0]
+        expected = 0
         self.nuplicator.setup([source_stream], self.outputs, None)
         self.nuplicator.execute()
         for output in self.outputs:
@@ -25,7 +25,7 @@ class NUplicatorFilterTest(unittest.TestCase):
 
     def test_simple_stream_shallow(self):
         source_stream = Stream([[["Moshi Moshi"], ["Kawaii Desu"]]])
-        expected = source_stream[0]
+        expected = [["Moshi Moshi"], ["Kawaii Desu"]]
         self.nuplicator.setup([source_stream], self.outputs, None)
         self.nuplicator.execute()
         # Changing the inner list, change should be reflected cause copy should be shallow
@@ -35,7 +35,7 @@ class NUplicatorFilterTest(unittest.TestCase):
 
     def test_simple_stream_deep(self):
         source_stream = Stream([[["Moshi Moshi"], ["Kawaii Desu"]]])
-        expected = source_stream[0]
+        expected = [["Moshi Moshi"], ["Kawaii Desu"]]
         nuplicator = NUplicatorFilter(
             inputs="in",
             outputs=["out1", "out2", "out3"],

--- a/test/filtering/filters/nuplicator_filter_test.py
+++ b/test/filtering/filters/nuplicator_filter_test.py
@@ -21,17 +21,17 @@ class NUplicatorFilterTest(unittest.TestCase):
         self.nuplicator.setup([source_stream], self.outputs, None)
         self.nuplicator.execute()
         for output in self.outputs:
-            self.assertEqual(output[0], expected)
+            self.assertEqual(output.read(), expected)
 
     def test_simple_stream_shallow(self):
         source_stream = Stream([[["Moshi Moshi"], ["Kawaii Desu"]]])
-        expected = [["Moshi Moshi"], ["Kawaii Desu"]]
+        expected = Stream([["Moshi Moshi"], ["Kawaii Desu"]])
         self.nuplicator.setup([source_stream], self.outputs, None)
         self.nuplicator.execute()
         # Changing the inner list, change should be reflected cause copy should be shallow
         expected[0].append("Hello")
         for output in self.outputs:
-            self.assertEqual(output[0], expected)
+            self.assertEqual(output, expected)
 
     def test_simple_stream_deep(self):
         source_stream = Stream([[["Moshi Moshi"], ["Kawaii Desu"]]])
@@ -46,4 +46,4 @@ class NUplicatorFilterTest(unittest.TestCase):
         # Changing the inner list, change should not be reflected cause copy should be deep
         expected[0].append("Hello")
         for output in self.outputs:
-            self.assertNotEqual(output[0], expected)
+            self.assertNotEqual(output, Stream(expected))

--- a/test/filtering/filters/nuplicator_filter_test.py
+++ b/test/filtering/filters/nuplicator_filter_test.py
@@ -1,13 +1,13 @@
 import unittest
 from otri.filtering.filters.nuplicator_filter import NUplicatorFilter
-from otri.filtering.stream import Stream
+from otri.filtering.stream import LocalStream
 
 
 class NUplicatorFilterTest(unittest.TestCase):
 
     def setUp(self):
-        self.source_stream = Stream()
-        self.outputs = [Stream() for _ in range(3)]
+        self.source_stream = LocalStream()
+        self.outputs = [LocalStream() for _ in range(3)]
         self.nuplicator = NUplicatorFilter(
             inputs="in",
             outputs=["out1", "out2", "out3"],
@@ -16,7 +16,7 @@ class NUplicatorFilterTest(unittest.TestCase):
         self.nuplicator.setup([self.source_stream], self.outputs, None)
 
     def test_simple_stream_copying(self):
-        source_stream = Stream(range(100))
+        source_stream = LocalStream(range(100))
         expected = 0
         self.nuplicator.setup([source_stream], self.outputs, None)
         self.nuplicator.execute()
@@ -26,7 +26,7 @@ class NUplicatorFilterTest(unittest.TestCase):
     def test_simple_stream_shallow(self):
         source_stream = [[["Moshi Moshi"], ["Kawaii Desu"]]]
         expected = source_stream[0]
-        self.nuplicator.setup([Stream(source_stream)], self.outputs, None)
+        self.nuplicator.setup([LocalStream(source_stream)], self.outputs, None)
         self.nuplicator.execute()
         # Changing the inner list, change should be reflected cause copy should be shallow
         expected[0].append("Hello")
@@ -34,7 +34,7 @@ class NUplicatorFilterTest(unittest.TestCase):
             self.assertEqual(output.read(), expected)
 
     def test_simple_stream_deep(self):
-        source_stream = Stream([[["Moshi Moshi"], ["Kawaii Desu"]]])
+        source_stream = LocalStream([[["Moshi Moshi"], ["Kawaii Desu"]]])
         expected = [["Moshi Moshi"], ["Kawaii Desu"]]
         nuplicator = NUplicatorFilter(
             inputs="in",
@@ -46,4 +46,4 @@ class NUplicatorFilterTest(unittest.TestCase):
         # Changing the inner list, change should not be reflected cause copy should be deep
         expected[0].append("Hello")
         for output in self.outputs:
-            self.assertNotEqual(output, Stream(expected))
+            self.assertNotEqual(output, LocalStream(expected))

--- a/test/filtering/filters/phase_filter_test.py
+++ b/test/filtering/filters/phase_filter_test.py
@@ -17,7 +17,7 @@ DEL_EXP = [{"a": -3}, {"a": -3}, {"a": -3}]
 class PhaseFilterTest(unittest.TestCase):
 
     def setUp(self):
-        self.input = Stream(EXAMPLE_ATOMS, is_closed=True)
+        self.input = Stream(EXAMPLE_ATOMS, closed=True)
         self.output = Stream()
         self.phase_filter = PhaseFilter(
             inputs="in",
@@ -28,14 +28,14 @@ class PhaseFilterTest(unittest.TestCase):
 
     def test_empty_stream(self):
         # Testing a single execute call on an empty input Stream closes the output as well
-        empty_closed_stream = Stream(is_closed=True)
+        empty_closed_stream = Stream(closed=True)
         self.phase_filter.setup([empty_closed_stream],[self.output],None)
         self.phase_filter.execute()
         self.assertTrue(self.output.is_closed())
 
     def test_call_after_closing(self):
         # Testing a single execute call on an empty input Stream closes the output as well
-        empty_closed_stream = Stream(is_closed=True)
+        empty_closed_stream = Stream(closed=True)
         self.phase_filter.setup([empty_closed_stream],[self.output],None)
         self.phase_filter.execute()
         # execute again, no error should arise
@@ -55,7 +55,7 @@ class PhaseMulFilterTest(unittest.TestCase):
 
     def test_simple_stream_applies(self):
         # Testing the method is applied to all the elements of the input stream
-        source_stream = Stream(EXAMPLE_ATOMS, is_closed=True)
+        source_stream = Stream(EXAMPLE_ATOMS, closed=True)
         output_stream = Stream()
         expected = MUL_EXP
         phase_filter = PhaseMulFilter(
@@ -74,7 +74,7 @@ class PhaseDeltaFilterTest(unittest.TestCase):
 
     def test_simple_stream_applies(self):
         # Testing the method is applied to all the elements of the input stream
-        source_stream = Stream(EXAMPLE_ATOMS, is_closed=True)
+        source_stream = Stream(EXAMPLE_ATOMS, closed=True)
         output_stream = Stream()
         expected = DEL_EXP
         phase_filter = PhaseDeltaFilter(

--- a/test/filtering/filters/phase_filter_test.py
+++ b/test/filtering/filters/phase_filter_test.py
@@ -1,5 +1,5 @@
-from otri.filtering.filters.phase_filter import *
-from otri.filtering.stream import Stream
+from otri.filtering.filters.phase_filter import PhaseFilter, PhaseDeltaFilter, PhaseMulFilter
+from otri.filtering.stream import LocalStream
 import unittest
 
 EXAMPLE_ATOMS = [
@@ -9,34 +9,36 @@ EXAMPLE_ATOMS = [
 ]
 EXAMPLE_DISTANCE = 3
 def ex_sum(x, y): return x + y
-SUM_EXP = Stream([{"a": 5}, {"a": 7}, {"a": 9}])
-MUL_EXP = Stream([{"a": 4}, {"a": 10}, {"a": 18}])
-DEL_EXP = Stream([{"a": -3}, {"a": -3}, {"a": -3}])
+
+
+SUM_EXP = LocalStream([{"a": 5}, {"a": 7}, {"a": 9}])
+MUL_EXP = LocalStream([{"a": 4}, {"a": 10}, {"a": 18}])
+DEL_EXP = LocalStream([{"a": -3}, {"a": -3}, {"a": -3}])
 
 
 class PhaseFilterTest(unittest.TestCase):
 
     def setUp(self):
-        self.input = Stream(EXAMPLE_ATOMS, closed=True)
-        self.output = Stream()
+        self.input = LocalStream(EXAMPLE_ATOMS, closed=True)
+        self.output = LocalStream()
         self.phase_filter = PhaseFilter(
             inputs="in",
             outputs="out",
-            keys_to_change={"a":ex_sum},
+            keys_to_change={"a": ex_sum},
             distance=EXAMPLE_DISTANCE
         )
 
     def test_empty_stream(self):
         # Testing a single execute call on an empty input Stream closes the output as well
-        empty_closed_stream = Stream(closed=True)
-        self.phase_filter.setup([empty_closed_stream],[self.output],None)
+        empty_closed_stream = LocalStream(closed=True)
+        self.phase_filter.setup([empty_closed_stream], [self.output], None)
         self.phase_filter.execute()
         self.assertTrue(self.output.is_closed())
 
     def test_call_after_closing(self):
         # Testing a single execute call on an empty input Stream closes the output as well
-        empty_closed_stream = Stream(closed=True)
-        self.phase_filter.setup([empty_closed_stream],[self.output],None)
+        empty_closed_stream = LocalStream(closed=True)
+        self.phase_filter.setup([empty_closed_stream], [self.output], None)
         self.phase_filter.execute()
         # execute again, no error should arise
         self.phase_filter.execute()
@@ -45,7 +47,7 @@ class PhaseFilterTest(unittest.TestCase):
     def test_simple_stream_applies(self):
         # Testing the method is applied to all the elements of the input stream
         expected = SUM_EXP
-        self.phase_filter.setup([self.input],[self.output],None)
+        self.phase_filter.setup([self.input], [self.output], None)
         while not self.output.is_closed():
             self.phase_filter.execute()
         self.assertEqual(self.output, expected)
@@ -55,8 +57,8 @@ class PhaseMulFilterTest(unittest.TestCase):
 
     def test_simple_stream_applies(self):
         # Testing the method is applied to all the elements of the input stream
-        source_stream = Stream(EXAMPLE_ATOMS, closed=True)
-        output_stream = Stream()
+        source_stream = LocalStream(EXAMPLE_ATOMS, closed=True)
+        output_stream = LocalStream()
         expected = MUL_EXP
         phase_filter = PhaseMulFilter(
             inputs="in",
@@ -64,7 +66,7 @@ class PhaseMulFilterTest(unittest.TestCase):
             keys_to_change=["a"],
             distance=EXAMPLE_DISTANCE
         )
-        phase_filter.setup([source_stream],[output_stream], None)
+        phase_filter.setup([source_stream], [output_stream], None)
         while not output_stream.is_closed():
             phase_filter.execute()
         self.assertEqual(output_stream, expected)
@@ -74,8 +76,8 @@ class PhaseDeltaFilterTest(unittest.TestCase):
 
     def test_simple_stream_applies(self):
         # Testing the method is applied to all the elements of the input stream
-        source_stream = Stream(EXAMPLE_ATOMS, closed=True)
-        output_stream = Stream()
+        source_stream = LocalStream(EXAMPLE_ATOMS, closed=True)
+        output_stream = LocalStream()
         expected = DEL_EXP
         phase_filter = PhaseDeltaFilter(
             inputs="in",
@@ -83,7 +85,7 @@ class PhaseDeltaFilterTest(unittest.TestCase):
             keys_to_change=["a"],
             distance=EXAMPLE_DISTANCE
         )
-        phase_filter.setup([source_stream],[output_stream], None)
+        phase_filter.setup([source_stream], [output_stream], None)
         while not output_stream.is_closed():
             phase_filter.execute()
         self.assertEqual(output_stream, expected)

--- a/test/filtering/filters/phase_filter_test.py
+++ b/test/filtering/filters/phase_filter_test.py
@@ -9,9 +9,9 @@ EXAMPLE_ATOMS = [
 ]
 EXAMPLE_DISTANCE = 3
 def ex_sum(x, y): return x + y
-SUM_EXP = [{"a": 5}, {"a": 7}, {"a": 9}]
-MUL_EXP = [{"a": 4}, {"a": 10}, {"a": 18}]
-DEL_EXP = [{"a": -3}, {"a": -3}, {"a": -3}]
+SUM_EXP = Stream([{"a": 5}, {"a": 7}, {"a": 9}])
+MUL_EXP = Stream([{"a": 4}, {"a": 10}, {"a": 18}])
+DEL_EXP = Stream([{"a": -3}, {"a": -3}, {"a": -3}])
 
 
 class PhaseFilterTest(unittest.TestCase):

--- a/test/filtering/filters/split_filter_test.py
+++ b/test/filtering/filters/split_filter_test.py
@@ -34,7 +34,7 @@ SWITCH_NONE = SWITCH + [[NONE_ATOM]]
 class SplitFilterTest(unittest.TestCase):
 
     def setUp(self):
-        self.input = Stream(EXAMPLE_DATA, is_closed=True)
+        self.input = Stream(EXAMPLE_DATA, closed=True)
         self.output = [Stream() for _ in range(4)]
         self.output_w_none = [Stream() for _ in range(5)]
         self.f = SplitFilter(
@@ -53,10 +53,10 @@ class SplitFilterTest(unittest.TestCase):
             ranges=VALUES,
             none_keys_output=None
         )
-        self.assertEqual(len(f.get_output_names()), len(VALUES)+1)
+        self.assertEqual(len(f.output_names), len(VALUES)+1)
 
     def test_outputs_include_none(self):
-        self.assertEqual(len(self.f.get_output_names()), len(VALUES)+2)
+        self.assertEqual(len(self.f.output_names), len(VALUES)+2)
 
     def test_simple_stream_ignore_none_left(self):
         # Testing the result for a simple Stream, while ignoring atoms that do not have the key.
@@ -122,7 +122,7 @@ class SplitFilterTest(unittest.TestCase):
 class SwitchFilterTest(unittest.TestCase):
 
     def setUp(self):
-        self.input = Stream(EXAMPLE_DATA, is_closed=True)
+        self.input = Stream(EXAMPLE_DATA, closed=True)
         self.output = [Stream() for _ in range(4)]
         self.output_w_none = [Stream() for _ in range(5)]
         self.f = SwitchFilter(
@@ -134,7 +134,7 @@ class SwitchFilterTest(unittest.TestCase):
         )
 
     def test_outputs_ignore_none(self):
-        self.assertEqual(len(self.f.get_output_names()), len(VALUES)+1)
+        self.assertEqual(len(self.f.output_names), len(VALUES)+1)
 
     def test_outputs_include_none(self):
         f = SwitchFilter(
@@ -145,17 +145,17 @@ class SwitchFilterTest(unittest.TestCase):
             cases=VALUES,
             none_keys_output="None"
         )
-        self.assertEqual(len(f.get_output_names()), len(VALUES)+2)
+        self.assertEqual(len(f.output_names), len(VALUES)+2)
 
     def test_empty_stream(self):
         # Testing a single execute call on an empty input Stream closes the output as well
-        self.f.setup([Stream(is_closed=True)],self.output,None)
+        self.f.setup([Stream(closed=True)],self.output,None)
         self.f.execute()
         self.assertTrue(self.output[0].is_closed())
 
     def test_call_after_closing(self):
         # Testing a single execute call on an empty input Stream closes the output as well
-        self.f.setup([Stream(is_closed=True)],self.output,None)
+        self.f.setup([Stream(closed=True)],self.output,None)
         self.f.execute()
         # execute again, no error should arise
         self.f.execute()
@@ -170,7 +170,7 @@ class SwitchFilterTest(unittest.TestCase):
             key=KEY,
             cases=VALUES
         )
-        f.setup([Stream([{KEY : 1}], is_closed=True)],self.output, None)
+        f.setup([Stream([{KEY : 1}], closed=True)],self.output, None)
         f.execute()
         self.assertEqual(self.output[0], [{KEY: 1}])
 

--- a/test/filtering/filters/split_filter_test.py
+++ b/test/filtering/filters/split_filter_test.py
@@ -1,5 +1,5 @@
 from otri.filtering.filters.split_filter import SplitFilter, SwitchFilter
-from otri.filtering.stream import Stream
+from otri.filtering.stream import LocalStream
 import unittest
 
 VALUES = (1, 2, 3)
@@ -8,37 +8,37 @@ NONE_ATOM = {"Hello": "There"}
 EXAMPLE_DATA = [{KEY: x} for x in range(5)] + [NONE_ATOM]
 
 SPLIT_L = [
-    Stream([{KEY: 0}, {KEY: 1}]),
-    Stream([{KEY: 2}]),
-    Stream([{KEY: 3}]),
-    Stream([{KEY: 4}])
+    LocalStream([{KEY: 0}, {KEY: 1}]),
+    LocalStream([{KEY: 2}]),
+    LocalStream([{KEY: 3}]),
+    LocalStream([{KEY: 4}])
 ]
 SPLIT_R = [
-    Stream([{KEY: 0}]),
-    Stream([{KEY: 1}]),
-    Stream([{KEY: 2}]),
-    Stream([{KEY: 3}, {KEY: 4}])
+    LocalStream([{KEY: 0}]),
+    LocalStream([{KEY: 1}]),
+    LocalStream([{KEY: 2}]),
+    LocalStream([{KEY: 3}, {KEY: 4}])
 ]
-SPLIT_L_NONE = SPLIT_L + [Stream([NONE_ATOM])]
-SPLIT_R_NONE = SPLIT_R + [Stream([NONE_ATOM])]
+SPLIT_L_NONE = SPLIT_L + [LocalStream([NONE_ATOM])]
+SPLIT_R_NONE = SPLIT_R + [LocalStream([NONE_ATOM])]
 
 SWITCH = [
     # Ordering is random for exact values
-    Stream([{KEY: 1}]),
-    Stream([{KEY: 2}]),
-    Stream([{KEY: 3}]),
+    LocalStream([{KEY: 1}]),
+    LocalStream([{KEY: 2}]),
+    LocalStream([{KEY: 3}]),
     # Default
-    Stream([{KEY: 0}, {KEY: 4}])
+    LocalStream([{KEY: 0}, {KEY: 4}])
 ]
-SWITCH_NONE = SWITCH + [Stream([NONE_ATOM])]
+SWITCH_NONE = SWITCH + [LocalStream([NONE_ATOM])]
 
 
 class SplitFilterTest(unittest.TestCase):
 
     def setUp(self):
-        self.input = Stream(EXAMPLE_DATA, closed=True)
-        self.output = [Stream() for _ in range(4)]
-        self.output_w_none = [Stream() for _ in range(5)]
+        self.input = LocalStream(EXAMPLE_DATA, closed=True)
+        self.output = [LocalStream() for _ in range(4)]
+        self.output_w_none = [LocalStream() for _ in range(5)]
         self.f = SplitFilter(
             inputs="A",
             outputs=["B", "C", "D", "E"],
@@ -61,7 +61,7 @@ class SplitFilterTest(unittest.TestCase):
         self.assertEqual(len(self.f.output_names), len(VALUES)+2)
 
     def test_simple_stream_ignore_none_left(self):
-        # Testing the result for a simple Stream, while ignoring atoms that do not have the key.
+        # Testing the result for a simple LocalStream, while ignoring atoms that do not have the key.
         f = SplitFilter(
             inputs="A",
             outputs=["B", "C", "D", "E"],
@@ -76,7 +76,7 @@ class SplitFilterTest(unittest.TestCase):
         self.assertEqual(self.output, SPLIT_L)
 
     def test_simple_stream_ignore_none_right(self):
-        # Testing the result for a simple Stream, while ignoring atoms that do not have the key.
+        # Testing the result for a simple LocalStream, while ignoring atoms that do not have the key.
         f = SplitFilter(
             inputs="A",
             outputs=["B", "C", "D", "E"],
@@ -91,7 +91,7 @@ class SplitFilterTest(unittest.TestCase):
         self.assertEqual(self.output, SPLIT_R)
 
     def test_simple_stream_split_none_left(self):
-        # Testing the result for a simple Stream, while ignoring atoms that do not have the key.
+        # Testing the result for a simple LocalStream, while ignoring atoms that do not have the key.
         f = SplitFilter(
             inputs="A",
             outputs=["B", "C", "D", "E"],
@@ -106,7 +106,7 @@ class SplitFilterTest(unittest.TestCase):
         self.assertEqual(self.output_w_none, SPLIT_L_NONE)
 
     def test_simple_stream_split_none_right(self):
-        # Testing the result for a simple Stream, while splitting atoms that do not have the key.
+        # Testing the result for a simple LocalStream, while splitting atoms that do not have the key.
         f = SplitFilter(
             inputs="A",
             outputs=["B", "C", "D", "E"],
@@ -124,9 +124,9 @@ class SplitFilterTest(unittest.TestCase):
 class SwitchFilterTest(unittest.TestCase):
 
     def setUp(self):
-        self.input = Stream(EXAMPLE_DATA, closed=True)
-        self.output = [Stream() for _ in range(4)]
-        self.output_w_none = [Stream() for _ in range(5)]
+        self.input = LocalStream(EXAMPLE_DATA, closed=True)
+        self.output = [LocalStream() for _ in range(4)]
+        self.output_w_none = [LocalStream() for _ in range(5)]
         self.f = SwitchFilter(
             inputs="A",
             cases_outputs=["B", "C", "D"],
@@ -150,14 +150,14 @@ class SwitchFilterTest(unittest.TestCase):
         self.assertEqual(len(f.output_names), len(VALUES)+2)
 
     def test_empty_stream(self):
-        # Testing a single execute call on an empty input Stream closes the output as well
-        self.f.setup([Stream(closed=True)],self.output,None)
+        # Testing a single execute call on an empty input LocalStream closes the output as well
+        self.f.setup([LocalStream(closed=True)],self.output,None)
         self.f.execute()
         self.assertTrue(self.output[0].is_closed())
 
     def test_call_after_closing(self):
-        # Testing a single execute call on an empty input Stream closes the output as well
-        self.f.setup([Stream(closed=True)],self.output,None)
+        # Testing a single execute call on an empty input LocalStream closes the output as well
+        self.f.setup([LocalStream(closed=True)],self.output,None)
         self.f.execute()
         # execute again, no error should arise
         self.f.execute()
@@ -172,12 +172,12 @@ class SwitchFilterTest(unittest.TestCase):
             key=KEY,
             cases=VALUES
         )
-        f.setup([Stream([{KEY : 1}], closed=True)],self.output, None)
+        f.setup([LocalStream([{KEY : 1}], closed=True)],self.output, None)
         f.execute()
-        self.assertEqual(self.output[0], Stream([{KEY: 1}]))
+        self.assertEqual(self.output[0], LocalStream([{KEY: 1}]))
 
     def test_simple_stream_ignore_none(self):
-        # Testing the result for a simple Stream, while ignoring atoms that do not have the key.
+        # Testing the result for a simple LocalStream, while ignoring atoms that do not have the key.
         self.f.setup([self.input],self.output,None)
         while not self.output[0].is_closed():
             self.f.execute()
@@ -186,7 +186,7 @@ class SwitchFilterTest(unittest.TestCase):
         self.assertEqual(self.output[-1], SWITCH[-1])
 
     def test_simple_stream_include_none(self):
-        # Testing the result for a simple Stream, while preserving atoms that do not have the key.
+        # Testing the result for a simple LocalStream, while preserving atoms that do not have the key.
         f = SwitchFilter(
             inputs="A",
             cases_outputs=["B", "C", "D"],

--- a/test/filtering/filters/split_filter_test.py
+++ b/test/filtering/filters/split_filter_test.py
@@ -8,27 +8,29 @@ NONE_ATOM = {"Hello": "There"}
 EXAMPLE_DATA = [{KEY: x} for x in range(5)] + [NONE_ATOM]
 
 SPLIT_L = [
-    [{KEY: 0}, {KEY: 1}],
-    [{KEY: 2}],
-    [{KEY: 3}],
-    [{KEY: 4}]
+    Stream([{KEY: 0}, {KEY: 1}]),
+    Stream([{KEY: 2}]),
+    Stream([{KEY: 3}]),
+    Stream([{KEY: 4}])
 ]
 SPLIT_R = [
-    [{KEY: 0}],
-    [{KEY: 1}],
-    [{KEY: 2}],
-    [{KEY: 3}, {KEY: 4}]
+    Stream([{KEY: 0}]),
+    Stream([{KEY: 1}]),
+    Stream([{KEY: 2}]),
+    Stream([{KEY: 3}, {KEY: 4}])
 ]
-SPLIT_L_NONE = SPLIT_L + [[NONE_ATOM]]
-SPLIT_R_NONE = SPLIT_R + [[NONE_ATOM]]
+SPLIT_L_NONE = SPLIT_L + [Stream([NONE_ATOM])]
+SPLIT_R_NONE = SPLIT_R + [Stream([NONE_ATOM])]
 
 SWITCH = [
     # Ordering is random for exact values
-    [{KEY: 1}], [{KEY: 2}], [{KEY: 3}],
+    Stream([{KEY: 1}]),
+    Stream([{KEY: 2}]),
+    Stream([{KEY: 3}]),
     # Default
-    [{KEY: 0}, {KEY: 4}]
+    Stream([{KEY: 0}, {KEY: 4}])
 ]
-SWITCH_NONE = SWITCH + [[NONE_ATOM]]
+SWITCH_NONE = SWITCH + [Stream([NONE_ATOM])]
 
 
 class SplitFilterTest(unittest.TestCase):
@@ -172,7 +174,7 @@ class SwitchFilterTest(unittest.TestCase):
         )
         f.setup([Stream([{KEY : 1}], closed=True)],self.output, None)
         f.execute()
-        self.assertEqual(self.output[0], [{KEY: 1}])
+        self.assertEqual(self.output[0], Stream([{KEY: 1}]))
 
     def test_simple_stream_ignore_none(self):
         # Testing the result for a simple Stream, while ignoring atoms that do not have the key.

--- a/test/filtering/filters/statistics_filter_test.py
+++ b/test/filtering/filters/statistics_filter_test.py
@@ -13,7 +13,7 @@ class StatisticsFilterTest(unittest.TestCase):
             outputs="out",
             keys=["a", "b", "c"]
         )
-        self.input = Stream(ATOMS, is_closed=True)
+        self.input = Stream(ATOMS, closed=True)
         self.output = Stream()
         self.state = dict()
         self.f.setup([self.input], [self.output], self.state)

--- a/test/filtering/filters/statistics_filter_test.py
+++ b/test/filtering/filters/statistics_filter_test.py
@@ -22,7 +22,7 @@ class StatisticsFilterTest(unittest.TestCase):
         # Checking the counting works
         self.f.calc_count("count")
         self.f.setup([self.input], [self.output], self.state)
-        while iter(self.input).has_next():
+        while self.input.has_next():
             self.f.execute()
         self.assertEqual(self.state["count"]["a"], 5)
 
@@ -30,7 +30,7 @@ class StatisticsFilterTest(unittest.TestCase):
         # Checking the sum works
         self.f.calc_sum("sum")
         self.f.setup([self.input], [self.output], self.state)
-        while iter(self.input).has_next():
+        while self.input.has_next():
             self.f.execute()
         self.assertEqual(self.state["sum"]["a"], 15)
 
@@ -38,7 +38,7 @@ class StatisticsFilterTest(unittest.TestCase):
         # Checking the avg works
         self.f.calc_avg("avg")
         self.f.setup([self.input], [self.output], self.state)
-        while iter(self.input).has_next():
+        while self.input.has_next():
             self.f.execute()
         self.assertEqual(self.state["avg"]["a"], 3)
 
@@ -46,7 +46,7 @@ class StatisticsFilterTest(unittest.TestCase):
         # Checking the max works
         self.f.calc_max("max")
         self.f.setup([self.input], [self.output], self.state)
-        while iter(self.input).has_next():
+        while self.input.has_next():
             self.f.execute()
         self.assertEqual(self.state["max"]["a"], 5)
 
@@ -54,7 +54,7 @@ class StatisticsFilterTest(unittest.TestCase):
         # Checking the min works
         self.f.calc_min("min")
         self.f.setup([self.input], [self.output], self.state)
-        while iter(self.input).has_next():
+        while self.input.has_next():
             self.f.execute()
         self.assertEqual(self.state["min"]["a"], 1)
 

--- a/test/filtering/filters/statistics_filter_test.py
+++ b/test/filtering/filters/statistics_filter_test.py
@@ -1,5 +1,5 @@
 from otri.filtering.filters.statistics_filter import StatisticsFilter
-from otri.filtering.stream import Stream
+from otri.filtering.stream import LocalStream
 import unittest
 
 ATOMS = [{"a": 1}, {"a": 2}, {"a": 3}, {"a": 4}, {"a": 5}, {"b": 6}, {"c": 7}]
@@ -13,8 +13,8 @@ class StatisticsFilterTest(unittest.TestCase):
             outputs="out",
             keys=["a", "b", "c"]
         )
-        self.input = Stream(ATOMS, closed=True)
-        self.output = Stream()
+        self.input = LocalStream(ATOMS, closed=True)
+        self.output = LocalStream()
         self.state = dict()
         self.f.setup([self.input], [self.output], self.state)
 

--- a/test/filtering/filters/threshold_filter_test.py
+++ b/test/filtering/filters/threshold_filter_test.py
@@ -47,7 +47,7 @@ class ThresholdFilterTest(unittest.TestCase):
 
     def test_step_01(self):
         f = ThresholdFilter(inputs="A", outputs="B", price_keys=['high'], step=lambda i: round(i*0.1, ndigits=3))
-        a = Stream(STREAM, is_closed=True)
+        a = Stream(STREAM, closed=True)
         b = Stream()
         state = dict()
         f.setup([a], [b], state)
@@ -57,7 +57,7 @@ class ThresholdFilterTest(unittest.TestCase):
 
     def test_step_05(self):
         f = ThresholdFilter(inputs="A", outputs="B", price_keys=['high'], step=lambda i: round(i*0.5, ndigits=3))
-        a = Stream(STREAM, is_closed=True)
+        a = Stream(STREAM, closed=True)
         b = Stream()
         state = dict()
         f.setup([a], [b], state)

--- a/test/filtering/filters/threshold_filter_test.py
+++ b/test/filtering/filters/threshold_filter_test.py
@@ -1,6 +1,6 @@
 import unittest
 from otri.filtering.filters.threshold_filter import ThresholdFilter
-from otri.filtering.stream import Stream
+from otri.filtering.stream import LocalStream
 
 STREAM = [
     {"high": 1.00},
@@ -47,8 +47,8 @@ class ThresholdFilterTest(unittest.TestCase):
 
     def test_step_01(self):
         f = ThresholdFilter(inputs="A", outputs="B", price_keys=['high'], step=lambda i: round(i*0.1, ndigits=3))
-        a = Stream(STREAM, closed=True)
-        b = Stream()
+        a = LocalStream(STREAM, closed=True)
+        b = LocalStream()
         state = dict()
         f.setup([a], [b], state)
         while not b.is_closed():
@@ -57,8 +57,8 @@ class ThresholdFilterTest(unittest.TestCase):
 
     def test_step_05(self):
         f = ThresholdFilter(inputs="A", outputs="B", price_keys=['high'], step=lambda i: round(i*0.5, ndigits=3))
-        a = Stream(STREAM, closed=True)
-        b = Stream()
+        a = LocalStream(STREAM, closed=True)
+        b = LocalStream()
         state = dict()
         f.setup([a], [b], state)
         while not b.is_closed():

--- a/test/filtering/stream_test.py
+++ b/test/filtering/stream_test.py
@@ -1,4 +1,4 @@
-from otri.filtering.stream import Stream, ClosedStreamError
+from otri.filtering.stream import LocalStream, ClosedStreamError
 import unittest
 
 sample_initial_list = [1, 2, 3, 4]
@@ -7,11 +7,11 @@ sample_initial_list = [1, 2, 3, 4]
 class StreamTest(unittest.TestCase):
 
     def setUp(self):
-        self.default_stream = Stream(sample_initial_list)
+        self.default_stream = LocalStream(sample_initial_list)
 
     def test_stream_append(self):
         self.default_stream.append(5)
-        self.assertEqual(Stream([1, 2, 3, 4, 5]), self.default_stream)
+        self.assertEqual(LocalStream([1, 2, 3, 4, 5]), self.default_stream)
 
     def test_closed_stream_append(self):
         self.default_stream.close()

--- a/test/filtering/stream_test.py
+++ b/test/filtering/stream_test.py
@@ -1,4 +1,4 @@
-from otri.filtering.stream import Stream, StreamIter
+from otri.filtering.stream import Stream, ClosedStreamError
 import unittest
 
 sample_initial_list = [1, 2, 3, 4]
@@ -9,53 +9,24 @@ class StreamTest(unittest.TestCase):
     def setUp(self):
         self.default_stream = Stream(sample_initial_list)
 
-    def test_iter_type(self):
-        # Testing iter type is StreamIter
-        self.assertTrue(isinstance(self.default_stream.__iter__(), StreamIter))
-
-    def test_iter_next_element(self):
-        # Testing that next pops the right element
-        self.assertEqual(1, next(self.default_stream.__iter__()))
-
-    def test_iter_next_leftover(self):
-        # Testing that next actually removes the element from the stream
-        next(self.default_stream.__iter__())
-        self.assertEqual([2, 3, 4], self.default_stream)
-
     def test_stream_append(self):
         self.default_stream.append(5)
         self.assertEqual([1, 2, 3, 4, 5], self.default_stream)
 
-    def test_stream_insert(self):
-        self.default_stream.insert(0, 5)
-        self.assertEqual([5, 1, 2, 3, 4], self.default_stream)
-
     def test_closed_stream_append(self):
         self.default_stream.close()
-        self.assertRaises(RuntimeError, self.default_stream.append, 5)
+        self.assertRaises(ClosedStreamError, self.default_stream.append, 5)
 
     def test_closed_stream_insert(self):
         self.default_stream.close()
-        self.assertRaises(RuntimeError, self.default_stream.insert, 0, 5)
+        self.assertRaises(CLosedStreamError, self.default_stream.insert, 0, 5)
 
     def test_streamIter_stream_has_next(self):
         self.assertTrue(self.default_stream.__iter__().has_next())
-
-    def test_streamIter_empty_stream_has_next(self):
-        stream = Stream()
-        self.assertFalse(stream.__iter__().has_next())
-
-    def test_streamIter_empty_stream_next(self):
-        stream = Stream()
-        self.assertRaises(StopIteration, next, iter(stream))
-
-    def test_streamIter_closed_stream_next_ok(self):
-        self.default_stream.close()
-        self.assertEqual(1,next(self.default_stream.__iter__()))
 
     def test_stream_is_open(self):
         self.assertFalse(self.default_stream.is_closed())
     
     def test_closed_stream_close_again(self):
         self.default_stream.close()
-        self.assertRaises(RuntimeError, self.default_stream.close)
+        self.assertRaises(CLosedStreamError, self.default_stream.close)

--- a/test/filtering/stream_test.py
+++ b/test/filtering/stream_test.py
@@ -11,22 +11,18 @@ class StreamTest(unittest.TestCase):
 
     def test_stream_append(self):
         self.default_stream.append(5)
-        self.assertEqual([1, 2, 3, 4, 5], self.default_stream)
+        self.assertEqual(Stream([1, 2, 3, 4, 5]), self.default_stream)
 
     def test_closed_stream_append(self):
         self.default_stream.close()
-        self.assertRaises(ClosedStreamError, self.default_stream.append, 5)
-
-    def test_closed_stream_insert(self):
-        self.default_stream.close()
-        self.assertRaises(CLosedStreamError, self.default_stream.insert, 0, 5)
+        self.assertRaises(ClosedStreamError, self.default_stream.push, 5)
 
     def test_streamIter_stream_has_next(self):
-        self.assertTrue(self.default_stream.__iter__().has_next())
+        self.assertTrue(self.default_stream.has_next())
 
     def test_stream_is_open(self):
         self.assertFalse(self.default_stream.is_closed())
     
     def test_closed_stream_close_again(self):
         self.default_stream.close()
-        self.assertRaises(CLosedStreamError, self.default_stream.close)
+        self.assertRaises(ClosedStreamError, self.default_stream.close)


### PR DESCRIPTION
## Premise
This PR takes care of [this Trello card](https://trello.com/c/XiUWYeWG).
It was written in September-October and hasn't been touched since, re-watched it, and seems reasonable.

## Features

#### `Stream` -> `LocalStream`
The stream is now only an interface, the Local stream (will rename it Local Queue) represents the collection that temporarily holds data between filters.
The old `Stream` is now only used to define open or close queue.

#### `Readable` and `Writable`
Not all streams (resp. queues) can be written on or can be read. A Stream can be either one of them or both. Methods that don't fit both were removed from Stream.

#### `LocalStream`
The old `Stream`, temporarily stores data in the local memory using a python `queue`.

#### stop `get`
Some `get_` are redundant and I removed them, in line with other python coding styles.

#### `VoidStream`
Removed "pass none if you want atoms to be discarded", now there exists the `VoidStream` that discards them.

## Polish cow sings about cocaine
![Cocaine](https://i.kym-cdn.com/entries/icons/original/000/034/909/sdfadfdafdfss.jpg)

NOTE: next PR will be about renaming stream to queue