### PR TITLE
Feat/summary filter

### DIFF
--- a/autocorrelation.py
+++ b/autocorrelation.py
@@ -71,6 +71,7 @@ def on_data_output():
     if(atoms_counter % 10 == 0):
         elapsed_counter.next(10)
 
+
 def none_filter(atom) -> dict:
     for key in REQUIRED_KEYS:
         if atom.get(key, None) is None:
@@ -172,9 +173,9 @@ def autocorrelation(input_stream: Stream, atom_keys: Collection, distance: int =
             time_took, count, count/time_took
         ))
 
-    log.d("Stats: {}".format(autocorr_net.state("Statistics", "Nope")))
+    log.d("Stats: {}".format(autocorr_net.state("Statistics", default="Nope")))
 
-    return autocorr_net.state("autocorrelation", 0)
+    return autocorr_net.state("autocorrelation", default=0)
 
 
 KEYS_TO_CHANGE = ("open", "high", "low", "close")
@@ -195,6 +196,8 @@ if __name__ == "__main__":
         with db_adapter.session() as session:
             atoms_table = db_adapter.get_classes()[DATABASE_TABLE]
             query = db_ticker_query(session, atoms_table, ticker)
+            # Create a DB stream with a batch size that also
+            # transforms db tuples in atoms.
             db_stream = db_adapter.stream(query, batch_size=1000, extract_atom=True)
         log.i("Beginning autocorr calc for {}".format(ticker))
         log.i("{} auto-correlation: {}".format(ticker, autocorrelation(db_stream, KEYS_TO_CHANGE)))

--- a/otri/filtering/filters/generic_filter.py
+++ b/otri/filtering/filters/generic_filter.py
@@ -34,7 +34,9 @@ class GenericFilter(Filter):
         '''
         Applies the operation on the atom then pushes it into the output
         '''
-        self._push_data(self.__operation(data))
+        atom = self.__operation(data)
+        if atom is not None:
+            self._push_data(atom)
 
 
 class MultipleGenericFiler(Filter):

--- a/otri/filtering/filters/generic_filter.py
+++ b/otri/filtering/filters/generic_filter.py
@@ -21,6 +21,7 @@ class GenericFilter(Filter):
                 The desired output stream name.
             operation : Callable
                 The operation that must be applied to the data of the input stream.
+                The function must take one parameter which is a datum and must return such datum edited or return None to discard it.
         '''
         super().__init__(
             inputs=[inputs],

--- a/otri/filtering/filters/interpolation_filter.py
+++ b/otri/filtering/filters/interpolation_filter.py
@@ -143,9 +143,9 @@ class IntradayInterpolationFilter(InterpolationFilter):
                     fp=[float(self.atom_buffer[key]), float(B[key])]
                 )
             except KeyError:
-                print("Atom doesn't contain key {}: {}".format(key, self.atom_buffer))
+                print("Atom doesn't contain key {}: {} or {}".format(key, self.atom_buffer, B))
             except TypeError:
-                print("Atom's key {} is not a number: {}".format(key, self.atom_buffer))
+                print("Atom's key {} is not a number: {} or {}".format(key, self.atom_buffer, B))
 
         # Generate intermediate atoms
         for i in range(len(interp_instants)):

--- a/otri/filtering/filters/summary_filter.py
+++ b/otri/filtering/filters/summary_filter.py
@@ -1,8 +1,10 @@
 from ..filter import Filter, Stream, Sequence, Mapping, Any
 from typing import Callable, Collection
+from ...utils import time_handler as th
 
 DEFAULT_STATE_NAME = "summary"
 RANGE_NAME = "range"
+DATE_RANGE = "dateRange"
 STRINGS_NAME = "strings"
 COUNT_NAME = "count"
 
@@ -54,6 +56,8 @@ class SummaryFilter(Filter):
         Calculates statistics then passes data to the output.
         '''
         for key, value in data.items():
+            if value is None:
+                continue
             key_state_dict = self.__state[self.__state_name].get(key, dict())
             if type(value) == int or type(value) == float or value.replace('.','',1).isnumeric(): # Numeric values
                 f_value = float(value)
@@ -63,6 +67,13 @@ class SummaryFilter(Filter):
                 if f_value > cur_range[1]:
                     cur_range[1] = f_value
                 key_state_dict[RANGE_NAME] = cur_range
+            elif th.is_datetime(value):
+                cur_range = key_state_dict.get(DATE_RANGE, ["9999999999999999999999999","0"])
+                if value < cur_range[0]:
+                    cur_range[0] = value
+                if value > cur_range[1]:
+                    cur_range[1] = value
+                key_state_dict[DATE_RANGE] = cur_range
             else:
                 cur_set = key_state_dict.get(STRINGS_NAME, set())
                 cur_set.add(value)

--- a/otri/filtering/filters/summary_filter.py
+++ b/otri/filtering/filters/summary_filter.py
@@ -1,0 +1,75 @@
+from ..filter import Filter, Stream, Sequence, Mapping, Any
+from typing import Callable, Collection
+
+DEFAULT_STATE_NAME = "summary"
+RANGE_NAME = "range"
+STRINGS_NAME = "strings"
+COUNT_NAME = "count"
+
+class SummaryFilter(Filter):
+    '''
+    Filter that calculates statistics on seen data.
+
+    Inputs:
+        A single queue of atoms/dicts.
+    Ouputs:
+        The same queue, nothing changed.
+    '''
+
+    def __init__(self, inputs: str, outputs: str, state_name = DEFAULT_STATE_NAME):
+        '''
+        Parameters:
+            inputs : str
+                Input stream name.
+            outputs : str
+                Output stream name.
+        '''
+        super().__init__(
+            inputs=[inputs],
+            outputs=[outputs],
+            input_count=1,
+            output_count=1
+        )
+        self.__state_name = state_name
+
+    def setup(self, inputs: Sequence[Stream], outputs: Sequence[Stream], state: Mapping[str, Any]):
+        '''
+        Used to save references to streams and reset variables.
+        Called once before the start of the execution in FilterNet.
+
+        Parameters:
+            inputs, outputs : Sequence[Stream]
+                Ordered sequence containing the required input/output streams gained from the FilterNet.
+            state : Mapping[str, Any]
+                Dictionary containing states to output.
+        '''
+        # Call superclass setup
+        super().setup(inputs, outputs, state)
+        # Save the state instance
+        self.__state = state
+        self.__state[self.__state_name] = dict()
+    
+    def _on_data(self, data, index):
+        '''
+        Calculates statistics then passes data to the output.
+        '''
+        for key, value in data.items():
+            key_state_dict = self.__state[self.__state_name].get(key, dict())
+            if type(value) == int or type(value) == float or value.replace('.','',1).isnumeric(): # Numeric values
+                f_value = float(value)
+                cur_range = key_state_dict.get(RANGE_NAME, [float("inf"),float("-inf")])
+                if f_value < cur_range[0]:
+                    cur_range[0] = f_value
+                if f_value > cur_range[1]:
+                    cur_range[1] = f_value
+                key_state_dict[RANGE_NAME] = cur_range
+            else:
+                cur_set = key_state_dict.get(STRINGS_NAME, set())
+                cur_set.add(value)
+                key_state_dict[STRINGS_NAME] = cur_set
+
+            # Occurrencies count
+            key_state_dict[COUNT_NAME]  = key_state_dict.get(COUNT_NAME, 0) + 1
+            self.__state[self.__state_name][key] = key_state_dict
+                
+        self._push_data(data)

--- a/otri/filtering/filters/summary_filter.py
+++ b/otri/filtering/filters/summary_filter.py
@@ -1,5 +1,5 @@
 from ..filter import Filter, Stream, Sequence, Mapping, Any
-from typing import Callable, Collection
+from typing import Collection
 from ...utils import time_handler as th
 
 DEFAULT_STATE_NAME = "summary"
@@ -59,7 +59,7 @@ class SummaryFilter(Filter):
             if value is None:
                 continue
             key_state_dict = self.__state[self.__state_name].get(key, dict())
-            if type(value) == int or type(value) == float or value.replace('.','',1).isnumeric(): # Numeric values
+            if isinstance(value, (int, float)) or value.replace('.','',1).isnumeric(): # Numeric values
                 f_value = float(value)
                 cur_range = key_state_dict.get(RANGE_NAME, [float("inf"),float("-inf")])
                 if f_value < cur_range[0]:

--- a/otri/utils/time_handler.py
+++ b/otri/utils/time_handler.py
@@ -1,6 +1,7 @@
 from datetime import datetime, time, timedelta
 from pytz import timezone, utc
 from tzlocal import get_localzone
+from typing import Union
 
 
 def str_to_datetime(string: str, tz: timezone = timezone("GMT")) -> datetime:
@@ -75,3 +76,10 @@ def sub_times(t1: time, t2: time) -> int:
     tmp_dt1 = datetime.combine(datetime(1, 1, 1), t1)
     tmp_dt2 = datetime.combine(datetime(1, 1, 1), t2)
     return (tmp_dt1 - tmp_dt2).total_seconds()
+
+def is_datetime(string : str) -> Union[bool, datetime]:
+    try:
+        dt = str_to_datetime(string)
+        return dt
+    except:
+        return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,14 @@
 # Data providers
-alpha-vantage==2.1.3
-yfinance==0.1.54
+alpha-vantage==2.3.1
+yfinance==0.1.59
 # Database driver
-psycopg2==2.8.5
-sqlalchemy==1.3.18
+psycopg2==2.8.6
+sqlalchemy==1.4.18
 # Time
 tzlocal==2.1
-pytz==2020.1
+pytz==2021.1
 # Misc utils
 xmltodict==0.12.0
 termcolor==1.1.0
 progress==1.5
-numpy==1.19.0
+numpy==1.20.3

--- a/test/filtering/filters/summary_filter_test.py
+++ b/test/filtering/filters/summary_filter_test.py
@@ -6,16 +6,19 @@ ATOMS = [
     {
         "open": 1.,
         "close": -2.,
-        "ticker": "Roberto"
+        "ticker": "Roberto",
+        "datetime": "2020-08-21 08:32:24.020"
     },
     {
         "open": 2.,
         "close": 3.,
-        "ticker": "Roberto"
+        "ticker": "Roberto",
+        "datetime": "2020-09-21 08:34:24.020"
     },
     {
         "open": 3.,
-        "ticker": "Ignazio"
+        "ticker": "Ignazio",
+        "datetime": "2020-10-22 07:32:24.020"
     },
     {
         "open": 4.,
@@ -44,6 +47,7 @@ EXPECTED_CLOSE = [-2., 8.]
 EXPECTED_CLOSE_STRINGS = {"Gianfranco", "Genoveffo"}
 EXPECTED_TICKER = {"Roberto", "Ignazio", "Luigi"}
 EXPECTED_TICKER_VALUES = [8., 8.]
+EXPECTED_DATETIME = ["2020-08-21 08:32:24.020","2020-10-22 07:32:24.020"]
 
 
 class SummaryFilterTest(unittest.TestCase):
@@ -68,3 +72,4 @@ class SummaryFilterTest(unittest.TestCase):
         self.assertEqual(self.state["Stats"]["close"]['strings'], EXPECTED_CLOSE_STRINGS)
         self.assertEqual(self.state["Stats"]["ticker"]['strings'], EXPECTED_TICKER)
         self.assertEqual(self.state["Stats"]["ticker"]['range'], EXPECTED_TICKER_VALUES)
+        self.assertEqual(self.state["Stats"]["datetime"]['dateRange'], EXPECTED_DATETIME)

--- a/test/filtering/filters/summary_filter_test.py
+++ b/test/filtering/filters/summary_filter_test.py
@@ -1,0 +1,70 @@
+from otri.filtering.filters.summary_filter import SummaryFilter
+from otri.filtering.stream import LocalStream
+import unittest
+
+ATOMS = [
+    {
+        "open": 1.,
+        "close": -2.,
+        "ticker": "Roberto"
+    },
+    {
+        "open": 2.,
+        "close": 3.,
+        "ticker": "Roberto"
+    },
+    {
+        "open": 3.,
+        "ticker": "Ignazio"
+    },
+    {
+        "open": 4.,
+        "close": "8.00",
+        "ticker": "Luigi"
+    },
+    {
+        "open": 5.,
+        "ticker": "8.00",
+        "close": "Gianfranco"
+    },
+    {
+        "open": 6.,
+        "close": "Gianfranco",
+        "ticker": "Luigi"
+    },
+    {
+        "open": 10.,
+        "close": "Genoveffo"
+    }
+]
+
+EXPECTED_OPEN = [1., 10.]
+EXPECTED_OPEN_COUNT = 7
+EXPECTED_CLOSE = [-2., 8.]
+EXPECTED_CLOSE_STRINGS = {"Gianfranco", "Genoveffo"}
+EXPECTED_TICKER = {"Roberto", "Ignazio", "Luigi"}
+EXPECTED_TICKER_VALUES = [8., 8.]
+
+
+class SummaryFilterTest(unittest.TestCase):
+
+    def setUp(self):
+        self.f = SummaryFilter(
+            inputs="in",
+            outputs="out",
+            state_name="Stats"
+        )
+        self.input = LocalStream(ATOMS, closed=True)
+        self.output = LocalStream()
+        self.state = dict()
+        self.f.setup([self.input], [self.output], self.state)
+
+    def test_summary(self):
+        while self.input.has_next():
+            self.f.execute()
+        self.assertEqual(self.state["Stats"]["open"]['range'], EXPECTED_OPEN)
+        self.assertEqual(self.state["Stats"]["open"]['count'], EXPECTED_OPEN_COUNT)
+        self.assertEqual(self.state["Stats"]["close"]['range'], EXPECTED_CLOSE)
+        self.assertEqual(self.state["Stats"]["close"]['strings'], EXPECTED_CLOSE_STRINGS)
+        self.assertEqual(self.state["Stats"]["ticker"]['strings'], EXPECTED_TICKER)
+        self.assertEqual(self.state["Stats"]["ticker"]['range'], EXPECTED_TICKER_VALUES)


### PR DESCRIPTION
## Premise
Created the Summary Filter we talked about some time ago.

## Features

#### `SummaryFilter`

The filter creates a `dict` for every key that it encounters in atoms, where it places:
- A range of values if they're numeric
- A range of dates if parsable
- The set of encountered strings

#### `autocorrelation`

- Added the summary filter after lowercasing
- Used the tuple extractor of the stream
- Added a filter that discards atoms that don't have required keys (None atoms) or its values are missing (None values).
- Used void queue to discard atoms at the end of process
- Changed policies to decrease the number of atoms in queues at any time (interpolator is producing more than consumed)

#### `GenericFilter`

- Added documentation on how the operation function parameter works.
- Added the possibility to append nothing to the output by returning None.

#### `TimeHandler`

- Added method to check whether a string is a datetime.

## What time were you born?

![Memotto arrubbato](https://i.kym-cdn.com/photos/images/newsfeed/001/953/286/99f.jpg)