### PR TITLE
Feat/on data callback

### DIFF
--- a/otri/filtering/filter_net.py
+++ b/otri/filtering/filter_net.py
@@ -38,15 +38,13 @@ class FilterNet:
         '''
         self.__layers.append(layer)
 
-    def execute(self, source: Mapping[str, Stream], on_data_output: Callable = None):
+    def execute(self, source: Mapping[str, Stream]):
         '''
-        Works on the source streams with the given filter layers
+        Works on the source streams with the given filter layers.
 
         Parameter:
             source : Mapping[str : Streams]
                 Source streams.
-            on_data_output : Callable
-                Function called everytime any filter from the last layer outputs something in any of its output streams.
         '''
         self.stream_dict.update(source)
         # Setup phase
@@ -64,11 +62,6 @@ class FilterNet:
                 fil.execute()
             # Check if it's finished
             if layer_index >= len(self.__layers) - 1:
-                # Call on_data_output if the last layer has outputted something
-                if on_data_output is not None and layer.has_outputted():
-                    for f in layer.filters:
-                        if f._has_outputted:
-                            on_data_output()
                 if self.__is_all_finished():
                     break
             # Ask the policy for the new layer index

--- a/test/filtering/callback_queue_test.py
+++ b/test/filtering/callback_queue_test.py
@@ -1,0 +1,90 @@
+import unittest
+from typing import Callable
+
+from otri.filtering.stream import CallbackQueue, LocalStream
+
+
+class CallbackQueueTest(unittest.TestCase):
+
+    def default_callback(self, data):
+        self.DEFAULT_1_CALLED = True
+
+    def default_callback_2(self, data):
+        self.DEFAULT_2_CALLED = True
+
+    def default_callback_3(self, data):
+        self.out_value = data
+
+    def setUp(self):
+        self.DEFAULT_1_CALLED = False
+        self.DEFAULT_2_CALLED = False
+        self.out_value = None
+        self.default_queue = CallbackQueue(callback=self.default_callback)
+
+    def test_constructor_callback(self):
+        self.default_queue.push("element")
+        self.assertTrue(self.DEFAULT_1_CALLED)
+
+    def test_multiple_callbacks(self):
+        self.default_queue.add_callback(callback=self.default_callback_2)
+        self.default_queue.push("element")
+        self.assertTrue(self.DEFAULT_1_CALLED)
+        self.assertTrue(self.DEFAULT_2_CALLED)
+
+    def test_passing_data_push(self):
+        '''Asserts that the method receives the right element'''
+        self.default_queue.add_callback(callback=self.default_callback_3)
+        self.default_queue.push("test_element")
+        self.assertEqual(self.out_value, "test_element")
+
+    def test_passing_data_push_all(self):
+        '''Asserts that the methods are called for every single element in the push_all argument'''
+        self.default_queue.add_callback(callback=self.default_callback_3)
+        self.default_queue.push_all(elements=["test_element1", "test_element2"])
+        self.assertEqual(self.out_value, "test_element2")
+
+# Testing class extension
+
+class LocalCallbackQueue(CallbackQueue, LocalStream):
+    pass
+
+
+class LocalCallbackQueueTest(unittest.TestCase):
+    '''Tests that callback functionalities still work when mixed with other queue types.'''
+
+    def default_callback(self, data):
+        self.DEFAULT_1_CALLED = True
+
+    def default_callback_2(self, data):
+        self.DEFAULT_2_CALLED = True
+
+    def default_callback_3(self, data):
+        self.out_value = data
+
+    def setUp(self):
+        self.DEFAULT_1_CALLED = False
+        self.DEFAULT_2_CALLED = False
+        self.out_value = None
+        self.default_queue = LocalCallbackQueue(callback=self.default_callback)
+
+    def test_constructor_callback(self):
+        self.default_queue.push("element")
+        self.assertTrue(self.DEFAULT_1_CALLED)
+
+    def test_multiple_callbacks(self):
+        self.default_queue.add_callback(callback=self.default_callback_2)
+        self.default_queue.push("element")
+        self.assertTrue(self.DEFAULT_1_CALLED)
+        self.assertTrue(self.DEFAULT_2_CALLED)
+
+    def test_passing_data_push(self):
+        '''Asserts that the method receives the right element'''
+        self.default_queue.add_callback(callback=self.default_callback_3)
+        self.default_queue.push("test_element")
+        self.assertEqual(self.out_value, "test_element")
+
+    def test_passing_data_push_all(self):
+        '''Asserts that the methods are called for every single element in the push_all argument'''
+        self.default_queue.add_callback(callback=self.default_callback_3)
+        self.default_queue.push_all(elements=["test_element1", "test_element2"])
+        self.assertEqual(self.out_value, "test_element2")

--- a/test/filtering/stream_test.py
+++ b/test/filtering/stream_test.py
@@ -1,5 +1,6 @@
-from otri.filtering.stream import LocalStream, ClosedStreamError
 import unittest
+
+from otri.filtering.stream import ClosedStreamError, LocalStream
 
 sample_initial_list = [1, 2, 3, 4]
 
@@ -22,7 +23,7 @@ class StreamTest(unittest.TestCase):
 
     def test_stream_is_open(self):
         self.assertFalse(self.default_stream.is_closed())
-    
+
     def test_closed_stream_close_again(self):
         self.default_stream.close()
         self.assertRaises(ClosedStreamError, self.default_stream.close)


### PR DESCRIPTION
## Premise
In [this Trello card](https://trello.com/c/SoYzAUq7) I raised the problem that a user might want to know when data is output even when the output queue is not one of the last layer's.

## Features
A solution I came up with is a callback queue class that can be inherited together with other writable queues which keeps a list of callbacks and calls them when new data is added to the queue.
Advantages of this approach are:
- Modularity: any queue can become callable, even a database push one.
- Reduced filter net complexity
- Switchable functionality: if the user never wants to use the callback functionality it can just ignore it and no code will be devoted to it.
- The user now knows that element has been pushed to the queue and can inspect it in the callback.

Everything is tested with what I could come up with.

## Picture of an E3 meme

![MayMays yay](https://i.kym-cdn.com/photos/images/newsfeed/002/124/496/183.jpg)